### PR TITLE
TL42-17 fix. MainSocial의 index.tsx에 대한 오타 수정

### DIFF
--- a/front-end/src/UI/Templates/MainSocial/index.tsx
+++ b/front-end/src/UI/Templates/MainSocial/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
-export function ProfileHeader() {
+export function MainSocial() {
   // return ();
 }


### PR DESCRIPTION
    ProfileHeader로 되어있는 export 함수 이름을 MainSocial로 올바르게
    수정하였다.