### PR TITLE
[TL42-14] fix: 백엔드 nginx및 DB문제 해결

### DIFF
--- a/back-end/src/app.module.ts
+++ b/back-end/src/app.module.ts
@@ -9,10 +9,10 @@ import { FriendModule } from './friend/friend.module';
 
 @Module({
   imports: [
-    // UsersModule,
-    // GameModule,
-    // TypeOrmModule.forRoot(typeORMConfig),
-    // FriendModule,
+    UsersModule,
+    GameModule,
+    TypeOrmModule.forRoot(typeORMConfig),
+    FriendModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/back-end/src/config/typeorm.config.ts
+++ b/back-end/src/config/typeorm.config.ts
@@ -5,11 +5,11 @@ import { User } from 'src/users/entities/user.entity';
 
 export const typeORMConfig: TypeOrmModuleOptions = {
   type: 'postgres',
-  host: 'localhost',
-  password: '1234',
+  host: 'database',
+  password: 'password',
   port: 5432,
-  username: 'postgres',
-  database: 'test',
+  username: 'transland',
+  database: 'transcendence',
   autoLoadEntities: true,
   entities: [User, GameRecord, Friend],
   synchronize: true,

--- a/config/nginx/reverse-proxy.conf
+++ b/config/nginx/reverse-proxy.conf
@@ -2,12 +2,13 @@ server {
     listen 80;
     listen [::]:80;
 
-    location /api {
+    location /api/ {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_pass http://back-end:3000;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://back-end:3000/;
     }
 
     location / {
@@ -15,6 +16,7 @@ server {
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_pass http://front-end:80;
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - 80:80
 
   database:
-    image: postgres:14.4
+    image: postgres:14-alpine
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
 - nginx 리버스 프록시에서, 요청 전달 시 /api/ 경로를 제거.
 - 어제 NestJS가 안켜져서 주석화 시켰던 모듈 import부분 모두 활성화.
 - PostgreSQL 컨테이너가 켜지지 않아서 14-alpine 버전으로 수정 : 잘켜짐
 - DB 연동 확인. pgadmin4 연결 잘 되는거 확인.