### PR TITLE
[TL42-69] fix: GAME_LEAVE_REQ 메시지 처리

### DIFF
--- a/back-end/src/socket/game/constants/game.constants.ts
+++ b/back-end/src/socket/game/constants/game.constants.ts
@@ -52,6 +52,7 @@ enum SocketEventName {
   GAME_CREATE_REQ = 'game-create-req',
   GAME_ENQUEUE_MATCH_REQ = 'game-enqueue-match-req',
   GAME_JOIN_REQ = 'game-join-req',
+  GAME_LEAVE_REQ = 'game-leave-req',
   PLAYER_MOVE_REQ = 'player-move-req',
 
   BALL_MOVE_NOTIFY = 'ball-move-notify',

--- a/back-end/src/socket/game/socket-game.service.ts
+++ b/back-end/src/socket/game/socket-game.service.ts
@@ -41,6 +41,14 @@ export class SocketGameService {
     this.queues.push(user);
   }
 
+  // 큐에서 특정 유저를 삭제하기.
+  private leaveQueue(user: UserContext) {
+    const index = this.queues.indexOf(user);
+    if (index > -1) {
+      this.queues.splice(index, 1);
+    }
+  }
+
   // 게임 큐에서, 연결되어 있는 플레이어 둘을 꺼내오기.
   private dequeue(): DequeueSuccessType | DequeueFalseType {
     if (this.queues.length < 2) {
@@ -96,6 +104,9 @@ export class SocketGameService {
     // 관전중인 방도 모두 퇴장
     user.gamesOnView.forEach((room) => room.leaveSpectator(user));
     user.gamesOnView.clear();
+
+    // 큐에 있었다면, 해당 유저를 매칭 큐에서 삭제.
+    this.leaveQueue(user);
   }
 
   @Interval(GAME_TIME_INTERVAL)

--- a/back-end/src/socket/socket.gateway.ts
+++ b/back-end/src/socket/socket.gateway.ts
@@ -53,7 +53,7 @@ export class SocketGateway implements OnGatewayConnection, OnGatewayDisconnect {
       this.userContexts.delete(client.id);
     }
 
-    console.log('Client disconnected');
+    console.log(`Client ${client.id} disconnected`);
   }
 
   @SubscribeMessage(SocketEventName.GAME_ENQUEUE_MATCH_REQ)
@@ -76,6 +76,17 @@ export class SocketGateway implements OnGatewayConnection, OnGatewayDisconnect {
         error: e.message,
       });
     }
+  }
+
+  @SubscribeMessage(SocketEventName.GAME_LEAVE_REQ)
+  handleGameLeave(@ConnectedSocket() client: Socket) {
+    const userContext = this.userContexts.get(client.id);
+
+    if (userContext) {
+      this.socketGameService.disconnect(userContext);
+    }
+
+    console.log(`Client ${client.id} leaved game screen`);
   }
 
   @SubscribeMessage(SocketEventName.PLAYER_MOVE_REQ)


### PR DESCRIPTION
 1. 클라이언트가 게임 화면을 '뒤로 가기' 등으로 나갈 때, 클라이언트의
   화면은 더 이상 게임 화면이 아님.
 2. 그러나 이에 대한 아무런 알림이 없기에 클라이언트가 게임 화면을 보고
    있는지, 아니면 뒤로 가기를 눌렀는지 서버는 알 방도가 없었음.
 3. 이에 대해서 클라이언트가 더 이상 게임 화면을 보고 있지 않다면
    게임을 나갔다는 메시지를 보내도록 수정하였음.

 - 이에 대한 서버의 처리 기능을 추가하였음.
 - leaveQueue 함수를 만들어서 이미 사용자가 큐에 있다면 그 사용자를
   큐에서 제거함.
 - disconnect 함수에서 leaveQueue 함수를 호출하게 하여, 모든 방에서 퇴장
   시키는 로직이 동작할 때, 함께 큐에서도 제거하게 하였음.
 - GAME_LEAVE_REQ 메시지를 받으면, 게임에서 나간 것(탈주 한 것)으로
   간주함. 따라서 disconnect 함수를 호출하게 하였음.