### PR TITLE
[TL42-85] feat: 로딩 화면에 디자인 추가

### DIFF
--- a/front-end/src/UI/Templates/Loading/index.tsx
+++ b/front-end/src/UI/Templates/Loading/index.tsx
@@ -1,17 +1,33 @@
 import React from 'react';
-import { Center, Spinner, Text } from '@chakra-ui/react';
+import {
+  Box,
+  Center,
+  Image,
+  SimpleGrid,
+  Spinner,
+  Text,
+} from '@chakra-ui/react';
 
 function Loading({ message }: { message: string }) {
   return (
-    <Center>
-      <Spinner
-        thickness="4px"
-        speed="0.65s"
-        emptyColor="gray.200"
-        color="blue.500"
-        size="xl"
-      />
-      <Text fontSize="4xl">{message}</Text>
+    <Center width="full" height="100vh" color="#fff">
+      <SimpleGrid columns={1} rowGap={14}>
+        <Center>
+          <Image src="/logo.svg" alt="logo" />
+        </Center>
+        <Center>
+          <Spinner
+            thickness="4px"
+            speed="0.65s"
+            emptyColor="gray.200"
+            color="blue.500"
+            size="xl"
+          />
+          <Box marginX={4}>
+            <Text fontSize="4xl">{message}</Text>
+          </Box>
+        </Center>
+      </SimpleGrid>
     </Center>
   );
 }


### PR DESCRIPTION
 - 기존에 어색하게 생긴 로딩 화면을 검은 배경에 로고를 붙이고, 내용을
   화면 가운데로 정렬시킴.

<img width="1310" alt="image" src="https://user-images.githubusercontent.com/40755203/181423211-ffb7d2dc-9d3d-400b-ba83-20fbd21501a3.png">
