### PR TITLE
[TL42-89] fe 친구 알림 대화 탭 분리 및 react router dom 연결

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -19,8 +19,8 @@ function App() {
           <SocketProvider>
             <BrowserRouter>
               <Routes>
-                <Route path="/" element={<Main />} />
                 <Route path="/game" element={<Game />} />
+                <Route path="/*" element={<Main />} />
               </Routes>
             </BrowserRouter>
           </SocketProvider>

--- a/front-end/src/UI/Atoms/TabListElement/index.tsx
+++ b/front-end/src/UI/Atoms/TabListElement/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { HStack, Icon, Tab, Text } from '@chakra-ui/react';
+import { IconType } from 'react-icons';
+
+export default function TabListElement({
+  icon,
+  label,
+}: {
+  icon: IconType;
+  label: string;
+}) {
+  return (
+    <Tab>
+      <HStack>
+        <Icon as={icon} />
+        <Text>{label}</Text>
+      </HStack>
+    </Tab>
+  );
+}

--- a/front-end/src/UI/Organisms/MainSocialSocial/index.tsx
+++ b/front-end/src/UI/Organisms/MainSocialSocial/index.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { Text } from '@chakra-ui/react';
-
-function MainSocialSocial() {
-  //  NAMING_CHECK
-  return <Text fontSize={50}>THIS IS MAIN SOCIAL SOCIAL</Text>;
-}
-
-export default MainSocialSocial;

--- a/front-end/src/UI/Organisms/MainSocialTabPanelChat/index.tsx
+++ b/front-end/src/UI/Organisms/MainSocialTabPanelChat/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Text } from '@chakra-ui/react';
+
+function ChatTab() {
+  return <Text fontSize={50}>THIS IS MAIN SOCIAL CHAT TAB</Text>;
+}
+
+export default ChatTab;

--- a/front-end/src/UI/Organisms/MainSocialTabPanelFriend/index.tsx
+++ b/front-end/src/UI/Organisms/MainSocialTabPanelFriend/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Text } from '@chakra-ui/react';
+
+function FriendTab() {
+  return <Text fontSize={50}>THIS IS MAIN SOCIAL FRIEND TAB</Text>;
+}
+
+export default FriendTab;

--- a/front-end/src/UI/Organisms/MainSocialTabPanelNotification/index.tsx
+++ b/front-end/src/UI/Organisms/MainSocialTabPanelNotification/index.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Text } from '@chakra-ui/react';
+
+function NotificationTab() {
+  return <Text fontSize={50}>THIS IS MAIN SOCIAL NOTIFICATION TAB</Text>;
+}
+
+export default NotificationTab;

--- a/front-end/src/UI/Organisms/MainSocialTabs/index.tsx
+++ b/front-end/src/UI/Organisms/MainSocialTabs/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { FaBell, FaUsers } from 'react-icons/fa';
+import { BsFillChatDotsFill } from 'react-icons/bs';
+import { TabPanels, TabList, Tabs, TabPanel } from '@chakra-ui/react';
+import FriendTab from '../MainSocialTabPanelFriend';
+import NotificationTab from '../MainSocialTabPanelNotification';
+import ChatTab from '../MainSocialTabPanelChat';
+import TabListElement from '../../Molecules/TabListElement';
+
+export default function SocialTabs() {
+  return (
+    <Tabs isFitted isManual>
+      <TabList mb="1em">
+        <TabListElement icon={FaUsers} label="친구" />
+        <TabListElement icon={FaBell} label="알림" />
+        <TabListElement icon={BsFillChatDotsFill} label="채팅" />
+      </TabList>
+      <TabPanels>
+        <TabPanel>
+          <FriendTab />
+        </TabPanel>
+        <TabPanel>
+          <NotificationTab />
+        </TabPanel>
+        <TabPanel>
+          <ChatTab />
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  );
+}

--- a/front-end/src/UI/Templates/MainSocial/index.tsx
+++ b/front-end/src/UI/Templates/MainSocial/index.tsx
@@ -1,13 +1,13 @@
 import { VStack } from '@chakra-ui/react';
 import React from 'react';
 import MyProfile from '../../Organisms/MainSocialMyProfile';
-import MainSocialSocial from '../../Organisms/MainSocialSocial';
+import SocialTabs from '../../Organisms/MainSocialTabs';
 
 function MainSocial() {
   return (
     <VStack h="100%">
       <MyProfile />
-      <MainSocialSocial />
+      <SocialTabs />
     </VStack>
   );
 }


### PR DESCRIPTION
 - 아이콘 및 텍스트를 갖는 탭 리스트 분자 컴포넌트를 만듦.
 - `/game` 경로는 게임을 위한 경로로 전달시킴.
 - 이외의 모든 경로는 `Main` 컴포넌트로 전달시켜 처리하도록 함.
 - 친구, 알림, 대화로 나누어진 탭 레이아웃을 추가.
 - `FriendTab`, `NotificationTab`, `ChatTab` 세 가지의 탭 유기체로 구분됨.
 - 네이밍을 일관성 있게 수정함.

<img src="https://user-images.githubusercontent.com/40755203/181474338-ec911252-5d6b-4fef-87a7-d0a5634bcb89.gif" width="300">
