### PR TITLE
[TL42-91] feat: 웹소켓 연결 시 쿼리 받게 수정

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -7,8 +7,21 @@ import Login from './UI/Pages/Login';
 import { SocketProvider } from './Hooks/useSocket';
 
 function App() {
+  // https://stackoverflow.com/questions/2090551/parse-query-string-in-javascript
+  // 브라우저 자체적으로 URL 주소를 파싱하기 위한 임시 처리임. 나중에는 필요 없을 예정.
+  function getQueryVariable(variable: string) {
+    const query = window.location.search.substring(1);
+    const vars = query.split('&');
+    for (let i = 0; i < vars.length; i += 1) {
+      const pair = vars[i].split('=');
+      if (decodeURIComponent(pair[0]) === variable) {
+        return decodeURIComponent(pair[1]);
+      }
+    }
+    return undefined;
+  }
   // TODO
-  const user = {}; // = useQuery(GET_USER);
+  const user = { id: getQueryVariable('user') }; // = useQuery(GET_USER);
 
   return (
     <ChakraProvider theme={theme}>
@@ -16,7 +29,7 @@ function App() {
         {user === null ? (
           <Login />
         ) : (
-          <SocketProvider>
+          <SocketProvider query={{ user: user.id }}>
             <BrowserRouter>
               <Routes>
                 <Route path="/" element={<Main />} />

--- a/front-end/src/Hooks/useSocket.tsx
+++ b/front-end/src/Hooks/useSocket.tsx
@@ -61,7 +61,13 @@ function SocketReducer(beforeState: SocketStateType, action: SocketActionType) {
   }
 }
 
-function SocketProvider({ children }: { children: React.ReactNode }) {
+function SocketProvider({
+  query,
+  children,
+}: {
+  query: { [key: string]: any };
+  children: React.ReactNode;
+}) {
   const [state, dispatch] = React.useReducer(SocketReducer, initialSocketState);
   const val = React.useMemo(() => ({ state, dispatch }), [state, dispatch]);
   React.useEffect(() => {
@@ -70,6 +76,7 @@ function SocketProvider({ children }: { children: React.ReactNode }) {
       {
         transports: ['websocket'],
         autoConnect: false,
+        query,
       },
     );
     dispatch({ action: 'connect', socket });
@@ -80,7 +87,7 @@ function SocketProvider({ children }: { children: React.ReactNode }) {
       dispatch({ action: 'connected' });
     });
     socket.connect();
-  }, []);
+  }, [query]);
   return (
     <SocketStateContext.Provider value={val}>
       {children}


### PR DESCRIPTION
 - 웹 소켓을 연결 할 때, 유저 토큰을 보낼 수 없어서 사용자를 식별할 수
   없는 문제가 있었음.
 - 이를 해결 하기 위해, URL을 파싱하여서 'user' 값을 웹소켓 쿼리로
   보내는 기능을 추가함.
 - 나중에는 유저 토큰을 URL에서 파싱해오는 것이 아니라, 백엔드 API를
   통해 얻어올 것임.



http://localhost:3001/?user=temporary-user-token

이런 식으로 사용하면 됩니다.