### PR TITLE
[TL42-92] feat: 사용자 컨텍스트 메뉴 템플릿 추가

### DIFF
--- a/front-end/src/UI/Atoms/ContextMenu/index.tsx
+++ b/front-end/src/UI/Atoms/ContextMenu/index.tsx
@@ -1,0 +1,111 @@
+/*
+ **  ContextMenu: chakra-ui-contextmenu
+ **
+ ** https://github.com/lukasbach/chakra-ui-contextmenu
+ */
+
+/* eslint-disable react/require-default-props */
+/* eslint-disable consistent-return */
+/* eslint-disable react-hooks/exhaustive-deps */
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable react/jsx-props-no-spreading */
+import * as React from 'react';
+import {
+  MutableRefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import {
+  useEventListener,
+  Portal,
+  Menu,
+  MenuButton,
+  PortalProps,
+  MenuButtonProps,
+  MenuProps,
+} from '@chakra-ui/react';
+
+export interface ContextMenuProps<T extends HTMLElement> {
+  renderMenu: () => JSX.Element | null;
+  children: (ref: MutableRefObject<T | null>) => JSX.Element | null;
+  menuProps?: MenuProps;
+  portalProps?: PortalProps;
+  menuButtonProps?: MenuButtonProps;
+}
+
+export function ContextMenu<T extends HTMLElement = HTMLElement>(
+  props: ContextMenuProps<T>,
+) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isRendered, setIsRendered] = useState(false);
+  const [isDeferredOpen, setIsDeferredOpen] = useState(false);
+  const [position, setPosition] = useState<[number, number]>([0, 0]);
+  const targetRef = useRef<T>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => {
+        setIsRendered(true);
+        setTimeout(() => {
+          setIsDeferredOpen(true);
+        });
+      });
+    } else {
+      setIsDeferredOpen(false);
+      const timeout = setTimeout(() => {
+        setIsRendered(isOpen);
+      }, 1000);
+      return () => clearTimeout(timeout);
+    }
+  }, [isOpen]);
+
+  useEventListener('contextmenu', (e) => {
+    if (
+      targetRef.current?.contains(e.target as any) ||
+      e.target === targetRef.current
+    ) {
+      e.preventDefault();
+      setIsOpen(true);
+      setPosition([e.pageX, e.pageY]);
+    } else {
+      setIsOpen(false);
+    }
+  });
+
+  const onCloseHandler = useCallback(() => {
+    props.menuProps?.onClose?.();
+    setIsOpen(false);
+  }, [props.menuProps?.onClose, setIsOpen]);
+
+  return (
+    <>
+      {props.children(targetRef)}
+      {isRendered && (
+        <Portal {...props.portalProps}>
+          <Menu
+            isOpen={isDeferredOpen}
+            gutter={0}
+            {...props.menuProps}
+            onClose={onCloseHandler}
+          >
+            <MenuButton
+              aria-hidden
+              w={1}
+              h={1}
+              style={{
+                position: 'absolute',
+                left: position[0],
+                top: position[1],
+                cursor: 'default',
+              }}
+              {...props.menuButtonProps}
+            />
+            {props.renderMenu()}
+          </Menu>
+        </Portal>
+      )}
+    </>
+  );
+}

--- a/front-end/src/UI/Organisms/MainSocialTabPanelFriend/index.tsx
+++ b/front-end/src/UI/Organisms/MainSocialTabPanelFriend/index.tsx
@@ -5,6 +5,7 @@ import SearchBar from '../../Atoms/SearchBar';
 import PopoverButton from '../PopoverButton';
 import ElementList from '../ElementList';
 import FriendElement from '../../Molecules/FriendElement';
+import UserContextMenu from '../../Templates/UserContextMenu';
 
 function FriendTab() {
   return (
@@ -14,8 +15,12 @@ function FriendTab() {
         <SearchBar />
       </HStack>
       <ElementList>
-        <FriendElement userName="Kanye West" connectionStatus="online" />
-        <FriendElement userName="Erling Haaland" connectionStatus="offline" />
+        <UserContextMenu mode="friend">
+          <FriendElement userName="Kanye West" connectionStatus="online" />
+        </UserContextMenu>
+        <UserContextMenu mode="chat">
+          <FriendElement userName="Erling Haaland" connectionStatus="offline" />
+        </UserContextMenu>
         <FriendElement userName="Benjamin Button" connectionStatus="ingame" />
       </ElementList>
     </VStack>

--- a/front-end/src/UI/Templates/UserContextMenu/index.tsx
+++ b/front-end/src/UI/Templates/UserContextMenu/index.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { MenuList, MenuItem } from '@chakra-ui/react';
+import styled from 'styled-components';
+import { ContextMenu } from '../../Atoms/ContextMenu';
+
+export type UserContextMenuType = 'friend' | 'chat';
+
+const ChildView = styled.div`
+  width: 100%;
+`;
+
+export default function UserContextMenu({
+  mode,
+  children,
+}: {
+  mode: UserContextMenuType;
+  children: React.ReactNode;
+}) {
+  return (
+    <ContextMenu
+      renderMenu={() => (
+        <MenuList>
+          <MenuItem>정보보기</MenuItem>
+          <MenuItem>게임초대</MenuItem>
+          <MenuItem>관전하기</MenuItem>
+          <MenuItem>친구추가</MenuItem>
+          <MenuItem>친구삭제</MenuItem>
+          <MenuItem>차단하기</MenuItem>
+          <MenuItem>차단해제</MenuItem>
+          {mode === 'chat' && <MenuItem>영구추방하기</MenuItem>}
+          {mode === 'chat' && <MenuItem>음소거시키기</MenuItem>}
+          {mode === 'chat' && <MenuItem>음소거해제</MenuItem>}
+          {mode === 'chat' && <MenuItem>관리자임명</MenuItem>}
+          {mode === 'chat' && <MenuItem>관리자해제</MenuItem>}
+        </MenuList>
+      )}
+    >
+      {(ref: any) => <ChildView ref={ref}>{children}</ChildView>}
+    </ContextMenu>
+  );
+}


### PR DESCRIPTION
 - Github 공개 ContextMenu 라이브러리를 사용해서, 사용자를 우클릭 할 때
   나오는 메뉴에 대한 템플릿을 구현.
 - 'mode' props를 사용해서 친구 또는 채팅에 대한 컨텍스트 메뉴를 구분할
   수 있게 함.
   - 추후, '나' 와 '상대 유저' 에 대한 값도 props를 통해 넘겨서, 검사할
     수 있게 하면 좋을 듯?

<img width="373" alt="image" src="https://user-images.githubusercontent.com/40755203/181677467-555f56d0-c874-47b0-b747-ca52f57d63f0.png">
<img width="358" alt="image" src="https://user-images.githubusercontent.com/40755203/181677491-e2daae86-4496-4e0a-bc2f-0c54ce2a7e55.png">
<img width="680" alt="image" src="https://user-images.githubusercontent.com/40755203/181677623-89273c6a-5c79-40fc-b34f-92c45bc196d1.png">


