### PR TITLE
[TL42-111] feat: 관전실패시 나오는 창 추가

### DIFF
--- a/front-end/src/UI/Molecules/SpectateMenu/index.tsx
+++ b/front-end/src/UI/Molecules/SpectateMenu/index.tsx
@@ -1,0 +1,57 @@
+import React, { useRef } from 'react';
+import {
+  MenuItem,
+  Text,
+  useDisclosure,
+  AlertDialog,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogBody,
+  AlertDialogFooter,
+  Button,
+  HStack,
+} from '@chakra-ui/react';
+import { WarningIcon } from '@chakra-ui/icons';
+import { MdSmartDisplay } from 'react-icons/md';
+
+function SpectateMenu() {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const cancelRef = useRef(null);
+  const success = false;
+
+  return (
+    <>
+      <MenuItem onClick={onOpen} icon={<MdSmartDisplay />}>
+        <Text>관전하기</Text>
+      </MenuItem>
+      {success === false && (
+        <AlertDialog
+          isOpen={isOpen}
+          leastDestructiveRef={cancelRef}
+          onClose={onClose}
+          isCentered
+        >
+          <AlertDialogOverlay>
+            <AlertDialogContent>
+              <AlertDialogHeader fontSize="lg" fontWeight="bold">
+                <HStack>
+                  <WarningIcon boxSize="1em" />
+                  <Text>엥 이게 뭐지</Text>
+                </HStack>
+              </AlertDialogHeader>
+              <AlertDialogBody>관전에 실패했습니다.</AlertDialogBody>
+              <AlertDialogFooter>
+                <Button colorScheme="green" ref={cancelRef} onClick={onClose}>
+                  OK
+                </Button>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialogOverlay>
+        </AlertDialog>
+      )}
+    </>
+  );
+}
+
+export default SpectateMenu;

--- a/front-end/src/UI/Templates/UserContextMenu/index.tsx
+++ b/front-end/src/UI/Templates/UserContextMenu/index.tsx
@@ -11,11 +11,11 @@ import {
 } from 'react-icons/fa';
 import { GiSpeaker, GiSpeakerOff } from 'react-icons/gi';
 import { GoSignOut } from 'react-icons/go';
-import { MdSmartDisplay } from 'react-icons/md';
 import { TbCrown, TbCrownOff } from 'react-icons/tb';
 import styled from 'styled-components';
 import { ContextMenu } from '../../Atoms/ContextMenu';
 import InviteGameMenu from '../../Molecules/InviteGameMenu';
+import SpectateMenu from '../../Molecules/SpectateMenu';
 
 export type UserContextMenuType = 'friend' | 'chat' | 'self';
 
@@ -56,7 +56,7 @@ export default function UserContextMenu({
             <>
               <MenuDivider />
               <InviteGameMenu />
-              <MenuItem icon={<MdSmartDisplay />}>관전하기</MenuItem>
+              <SpectateMenu />
             </>
           )}
           {mode === 'chat' && (


### PR DESCRIPTION
컨텍스트 메뉴 중 관전하기에 실패했을 경우 나오는 창 컴포넌트를 추가.
<img width="956" alt="image" src="https://user-images.githubusercontent.com/69182505/182338455-884383fb-b9b7-49ea-bf57-d4bd67ab228d.png">
