### PR TITLE
[TL42-148] feat: Friend API 정리

### DIFF
--- a/back-end/src/alert/alert.Repository.ts
+++ b/back-end/src/alert/alert.Repository.ts
@@ -1,6 +1,11 @@
+import {
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { CustomRepository } from 'src/custom/typeorm.decorator';
 import { User } from 'src/users/entities/user.entity';
 import { Equal, Repository } from 'typeorm';
+import { AlertDto } from './dto/alert.dto';
 import { Alert } from './entities/alert.entity';
 
 @CustomRepository(Alert)
@@ -11,8 +16,12 @@ export class AlertRepository extends Repository<Alert> {
       receiver,
       read: false,
     });
-    console.log(alert);
-    await this.save(alert);
+    try {
+      await this.save(alert);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
+    console.log(alert.id);
   }
 
   async findOneById(id: string): Promise<Alert> {
@@ -31,7 +40,11 @@ export class AlertRepository extends Repository<Alert> {
   async updateAlert(id: string): Promise<Alert> {
     const alertId = await this.findOneById(id);
     alertId.read = true;
-    await this.save(alertId);
+    try {
+      await this.save(alertId);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
     return alertId;
   }
 

--- a/back-end/src/alert/alert.service.ts
+++ b/back-end/src/alert/alert.service.ts
@@ -5,6 +5,7 @@ import { AlertRepository } from './alert.Repository';
 import { UserRepository } from 'src/users/users.repository';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ApiOperation } from '@nestjs/swagger';
+import { User } from 'src/users/entities/user.entity';
 
 @Injectable()
 export class AlertService {
@@ -15,14 +16,8 @@ export class AlertService {
     private userRepository: UserRepository,
   ) {}
 
-  async createAlert(alertDto: AlertDto): Promise<void> {
-    const requestor = await this.userRepository.findByNickname(
-      alertDto.requestor,
-    );
-    const receiver = await this.userRepository.findByNickname(
-      alertDto.receiver,
-    );
-    return this.alertRepository.createAlert(requestor, receiver);
+  async createAlert(user: User, opponentUser: User): Promise<void> {
+    await this.alertRepository.createAlert(user, opponentUser);
   }
 
   async findAll(nickName: string): Promise<Alert[]> {

--- a/back-end/src/chat/chat.controller.ts
+++ b/back-end/src/chat/chat.controller.ts
@@ -6,14 +6,12 @@ import {
   Patch,
   Param,
   Delete,
-  ConsoleLogger,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { ChatService } from './chat.service';
 import { ChatRoom } from './entities/chat.room.entity';
 import { CreateChatRoomDto } from './dto/create.chat.room.dto';
 import { UpdateChatPasswordDto } from './dto/update.chat.password.dto';
-import { ChatRole } from './constants/chat.role.enum';
 import { UpdateRoleDto } from './dto/update.role.dto';
 import { ChatRoomDto } from './dto/chat.room.dto';
 import { ChatDto } from 'src/chat/dto/chat.dto';

--- a/back-end/src/chat/chat.room.repository.ts
+++ b/back-end/src/chat/chat.room.repository.ts
@@ -1,4 +1,7 @@
-import { ConflictException } from '@nestjs/common';
+import {
+  ConflictException,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { CustomRepository } from 'src/custom/typeorm.decorator';
 import { Equal, Repository } from 'typeorm';
 import { CreateChatRoomDto } from './dto/create.chat.room.dto';
@@ -22,7 +25,11 @@ export class ChatRoomRepository extends Repository<ChatRoom> {
       type,
       password: encryptPassword,
     });
-    await this.save(chatRoom);
+    try {
+      await this.save(chatRoom);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
     return chatRoom;
   }
 
@@ -42,7 +49,11 @@ export class ChatRoomRepository extends Repository<ChatRoom> {
       chatRoom.password = null;
       chatRoom.type = ChatType.PUBLIC;
     }
-    await this.save(chatRoom);
+    try {
+      await this.save(chatRoom);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
     return chatRoom;
   }
 

--- a/back-end/src/chat/chat.service.ts
+++ b/back-end/src/chat/chat.service.ts
@@ -1,4 +1,8 @@
-import { ConflictException, Injectable } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ChatRoomRepository } from './chat.room.repository';
 import { ChatRoom } from './entities/chat.room.entity';
@@ -206,7 +210,11 @@ export class ChatService {
     muteTime.setMinutes(muteTime.getMinutes() + muteMinutes);
 
     chatUser.unmutedAt = muteTime;
-    await this.chatUserRepository.save(chatUser);
+    try {
+      await this.chatUserRepository.save(chatUser);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
 
     setTimeout(async () => {
       chatUser.unmutedAt = null;
@@ -254,6 +262,10 @@ export class ChatService {
     }
 
     chatUser.unmutedAt = null;
-    await this.chatUserRepository.save(chatUser);
+    try {
+      await this.chatUserRepository.save(chatUser);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
   }
 }

--- a/back-end/src/chat/chat.user.repository.ts
+++ b/back-end/src/chat/chat.user.repository.ts
@@ -5,7 +5,10 @@ import { ChatRole } from './constants/chat.role.enum';
 import { ChatRoom } from './entities/chat.room.entity';
 import { ChatUser } from './entities/chat.user.entity';
 import * as bcrypt from 'bcrypt';
-import { NotFoundException } from '@nestjs/common';
+import {
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 
 @CustomRepository(ChatUser)
 export class ChatUserRepository extends Repository<ChatUser> {
@@ -15,7 +18,11 @@ export class ChatUserRepository extends Repository<ChatUser> {
       chatRoom,
       role: ChatRole.OWNER,
     });
-    await this.save(chatUser);
+    try {
+      await this.save(chatUser);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
   }
 
   async findChatUser(user: User, chatRoom: ChatRoom): Promise<ChatUser> {
@@ -43,14 +50,26 @@ export class ChatUserRepository extends Repository<ChatUser> {
     newAdmin.role = ChatRole.ADMIN;
     if (oldAdmin !== null) {
       oldAdmin.role = ChatRole.PARTICIPANT;
-      await this.save(oldAdmin);
+      try {
+        await this.save(oldAdmin);
+      } catch (error) {
+        throw new InternalServerErrorException();
+      }
     }
-    await this.save(newAdmin);
+    try {
+      await this.save(newAdmin);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
   }
 
   async updateOwnerRole(user: ChatUser): Promise<void> {
     user.role = ChatRole.OWNER;
-    await this.save(user);
+    try {
+      await this.save(user);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
   }
 
   async findNewOwner(chatRoom: ChatRoom): Promise<ChatUser> {
@@ -100,7 +119,11 @@ export class ChatUserRepository extends Repository<ChatUser> {
       chatRoom,
       role: ChatRole.PARTICIPANT,
     });
-    await this.save(chatUser);
+    try {
+      await this.save(chatUser);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
   }
 
   async leaveChatRoom(user: User, chatRoom: ChatRoom): Promise<void> {

--- a/back-end/src/dm/dm.repository.ts
+++ b/back-end/src/dm/dm.repository.ts
@@ -1,3 +1,4 @@
+import { InternalServerErrorException } from '@nestjs/common';
 import { CustomRepository } from 'src/custom/typeorm.decorator';
 import { User } from 'src/users/entities/user.entity';
 import { Equal, Repository } from 'typeorm';
@@ -11,7 +12,11 @@ export class DMRepository extends Repository<Dm> {
       receiver,
       content,
     });
-    await this.save(DM);
+    try {
+      await this.save(DM);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
     return DM;
   }
 

--- a/back-end/src/friend/friend.controller.ts
+++ b/back-end/src/friend/friend.controller.ts
@@ -1,24 +1,18 @@
 import {
-  Body,
   Controller,
   Delete,
   Get,
   Param,
   Patch,
-  Post,
   Put,
-  UseFilters,
   UseGuards,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { FriendDto } from './dto/friend.dto';
-import { FriendAlertDto } from './dto/friendAlert.dto';
 import { FriendService } from './friend.service';
 import { Friend } from './entities/friend.entity';
 import { AuthGuard } from '@nestjs/passport';
 import { GetUser } from 'src/users/get.user.decorator';
 import { User } from 'src/users/entities/user.entity';
-import { DeleteResult } from 'typeorm';
 
 @ApiTags('Friend')
 @Controller('friend')
@@ -27,62 +21,66 @@ export class FriendController {
   constructor(private friendService: FriendService) {}
 
   @ApiOperation({ summary: '친구 전체 조회' })
-  @ApiResponse({ status: 204, description: 'success' })
+  @ApiResponse({ status: 200, description: '성공' })
+  @ApiResponse({ status: 400, description: '요청이 잘못됐을 때' })
   @Get()
-  findAllFriends(@GetUser() user: User): Promise<Friend[]> {
+  findAllFriends(@GetUser() user: User): Promise<User[]> {
     return this.friendService.findAllFriends(user);
   }
 
-  @ApiOperation({ summary: '친구 검색' })
-  @ApiResponse({ status: 204, description: 'success' })
-  @Get('/search/:nickname')
-  searchFriend(
-    @Param('nickname') nickname: string,
-    @GetUser() user: User,
-  ): Promise<Friend[]> {
-    return this.friendService.searchFriend(user, nickname);
-  }
-
   @ApiOperation({ summary: '친구 요청' })
-  @ApiResponse({ status: 204, description: 'success' })
+  @ApiResponse({ status: 200, description: '성공' })
   @ApiResponse({ status: 400, description: '요청이 잘못됐을 때' })
   @ApiResponse({ status: 404, description: '없는 유저를 요청했을 때' })
+  @ApiResponse({ status: 409, description: '이미 친구인 유저에게 요청했을 때' })
+  @ApiResponse({ status: 500, description: '서버 에러' })
   @Put('request/:nickname')
   requestFriend(
     @Param('nickname') nickname: string,
     @GetUser() user: User,
-  ): Promise<Friend> {
+  ): Promise<void> {
     return this.friendService.requestFriend(user, nickname);
   }
 
   @ApiOperation({ summary: '친구 수락' })
-  @ApiResponse({ status: 204, description: 'success' })
-  @Patch('accept/:nickname')
+  @ApiResponse({ status: 200, description: '성공' })
+  @ApiResponse({ status: 400, description: '요청이 잘못됐을 때' })
+  @ApiResponse({ status: 404, description: '없는 유저를 요청했을 때' })
+  @ApiResponse({ status: 500, description: '서버 에러' })
+  @Patch('accept/:alertId/:userId')
   acceptFriend(
-    @Param('nickname') nickname: string,
+    @Param('alertId') alertId: string,
+    @Param('userId') userId: string,
     @GetUser() user: User,
-  ): Promise<Friend> {
-    return this.friendService.acceptFriend(user, nickname);
+  ): Promise<void> {
+    return this.friendService.acceptFriend(user, alertId, userId);
   }
 
   // 201: success , 404: error
-  @ApiResponse({ status: 204, description: 'success' })
   @ApiOperation({ summary: '친구 거절' })
-  @Delete('reject/:nickname')
+  @ApiResponse({ status: 200, description: '성공' })
+  @ApiResponse({ status: 400, description: '요청이 잘못됐을 때' })
+  @ApiResponse({ status: 404, description: '없는 유저를 요청했을 때' })
+  @ApiResponse({ status: 500, description: '서버 에러' })
+  @Delete('reject/:alertId/:userId')
   rejectFriend(
-    @Param('nickname') nickname: string,
+    @Param('alertId') alertId: string,
+    @Param('userId') userId: string,
     @GetUser() user: User,
-  ): Promise<DeleteResult> {
-    return this.friendService.rejectFriend(user, nickname);
+  ): Promise<void> {
+    return this.friendService.rejectFriend(user, alertId, userId);
   }
 
   @ApiOperation({ summary: '친구 차단' })
-  @ApiResponse({ status: 201, description: 'success' })
-  @Post('block/:nickname')
+  @ApiResponse({ status: 200, description: '성공' })
+  @ApiResponse({ status: 400, description: '요청이 잘못됐을 때' })
+  @ApiResponse({ status: 404, description: '없는 유저를 요청했을 때' })
+  @ApiResponse({ status: 500, description: '서버 에러' })
+  @Patch('block/:nickname')
   blockFriend(
     @Param('nickname') nickname: string,
     @GetUser() user: User,
-  ): Promise<Friend> {
+  ): Promise<void> {
     return this.friendService.blockFriend(user, nickname);
   }
 }

--- a/back-end/src/friend/friend.repository.ts
+++ b/back-end/src/friend/friend.repository.ts
@@ -1,32 +1,35 @@
-import { ConflictException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { User } from 'src/users/entities/user.entity';
-import { DeleteResult, Equal, Repository } from 'typeorm';
+import { Equal, Repository } from 'typeorm';
 import { CustomRepository } from '../custom/typeorm.decorator';
-import { FriendDto } from './dto/friend.dto';
 import { Friend } from './entities/friend.entity';
 import { FriendStatus } from './constants/friend.enum';
 
 @CustomRepository(Friend)
 export class FriendRepository extends Repository<Friend> {
-  async requestFriend(requestor: User, receiver: User): Promise<Friend> {
+  async requestFriend(requestor: User, receiver: User): Promise<void> {
     // 친구 요청을 했는데, 상대방이 이 친구를 차단했다면 요청 자체가 안가도록.
     const resultOp = await this.findRow(receiver, requestor);
     if (resultOp !== null && resultOp.block === true) {
-      throw new ConflictException([`상대방이 차단, 요청 불가`]);
+      throw new BadRequestException([`상대방이 차단, 요청 불가`]);
     }
 
     const result: Friend = await this.findRow(requestor, receiver);
     if (result !== null) {
-      // 예외처리 변경하기
       if (result.block === true) {
-        throw new ConflictException([
+        throw new BadRequestException([
           `차단한 유저에게 친구요청을 보내셨습니다.`,
         ]);
       }
       if (result.status === FriendStatus.FRIEND) {
-        throw new NotFoundException([`이미 친구입니다.`]);
+        throw new BadRequestException([`이미 친구입니다.`]);
       } else if (result.status === FriendStatus.PENDDING) {
-        throw new NotFoundException([`이미 친구 요청 보냈습니다.`]);
+        throw new ConflictException([`이미 친구 요청 보냈습니다.`]);
       }
     }
     const friend = this.create({
@@ -34,12 +37,14 @@ export class FriendRepository extends Repository<Friend> {
       receiver,
       status: FriendStatus.PENDDING,
     });
-    await this.save(friend);
-    return friend;
-    // 자기자신에게 친구요청하는 경우도 예외처리 할것인지 생각필요.
+    try {
+      await this.save(friend);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
   }
 
-  async acceptFriend(requestor: User, receiver: User): Promise<Friend> {
+  async acceptFriend(requestor: User, receiver: User): Promise<void> {
     // friend DB에 관계가 있는지 확인
     // PENDDING -> FRIEND (Update)
     // accept 무조건 1번만 들어온다고 가정. (재요청 불가)
@@ -51,50 +56,58 @@ export class FriendRepository extends Repository<Friend> {
     const foundCreate: Friend = await this.findRow(receiver, requestor);
 
     if (foundUpdate.status !== FriendStatus.PENDDING) {
-      // 에러 핸들링은 나중에 적절하게 MDN보고 바꾸기
-      throw new ConflictException([`요청이 오지 않았다.`]);
+      throw new BadRequestException([`요청이 오지 않았다.`]);
     }
     if (foundCreate !== null && foundCreate.block === true) {
-      throw new ConflictException([`차단한 유저의 친구요청을 수락하셨습니다.`]);
+      throw new BadRequestException([
+        `차단한 유저의 친구요청을 수락하셨습니다.`,
+      ]);
     }
     foundUpdate.status = FriendStatus.FRIEND;
-    await this.save(foundUpdate);
+    try {
+      await this.save(foundUpdate);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
     const friend = this.create({
       requestor: receiver,
       receiver: requestor,
       status: FriendStatus.FRIEND,
       block: false,
     });
-    await this.save(friend);
-    return friend;
+    try {
+      await this.save(friend);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
   }
 
-  async rejectFriend(requestor: User, receiver: User): Promise<DeleteResult> {
+  async rejectFriend(requestor: User, receiver: User): Promise<void> {
     const result = await this.delete({
       requestor: { id: Equal(requestor.id) },
       receiver: { id: Equal(receiver.id) },
       status: FriendStatus.PENDDING,
     });
     if (result.affected === 0) {
-      throw new NotFoundException([
-        `Friend with ${requestor.nickname} which status is ${FriendStatus.PENDDING} not found.`,
-      ]);
+      throw new BadRequestException([`친구 요청이 오지 않았습니다.`]);
     }
-    return result;
   }
 
   // 모든 유저를 차단할 수 있다.
-  async blockFriend(requestor: User, receiver: User): Promise<Friend> {
+  async blockFriend(requestor: User, receiver: User): Promise<void> {
     const result: Friend = await this.findRow(requestor, receiver);
 
     // 이미 차단된 상태가 아니면 block true로 차단시킨다.
     if (result !== null) {
       if (result.block === true) {
-        throw new NotFoundException([`이미 차단한 유저 입니다.`]);
+        throw new BadRequestException([`이미 차단한 유저 입니다.`]);
       }
       result.block = true;
-      await this.save(result);
-      return result;
+      try {
+        await this.save(result);
+      } catch (error) {
+        throw new InternalServerErrorException();
+      }
     }
 
     // 관계가 없던 상태라 block으로 만들어서 저장
@@ -104,8 +117,11 @@ export class FriendRepository extends Repository<Friend> {
       status: FriendStatus.NONE,
       block: true,
     });
-    await this.save(friend);
-    return friend;
+    try {
+      await this.save(friend);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
   }
 
   async findRow(requestor: User, receiver: User): Promise<Friend> {
@@ -122,7 +138,7 @@ export class FriendRepository extends Repository<Friend> {
     return result;
   }
 
-  async findAllFriends(user: User): Promise<Friend[]> {
+  async findAllFriends(user: User): Promise<User[]> {
     /* 친구인 경우, 자기 자신이 requestor 혹은 receiver 둘 중 하나에는 무조건 있기 때문에
        requestor가 자기 자신인 경우를 찾아 반환한다.*/
     const result = await this.find({
@@ -135,29 +151,11 @@ export class FriendRepository extends Repository<Friend> {
         status: FriendStatus.FRIEND,
       },
     });
-    if (Object.keys(result).length === 0) {
-      throw new NotFoundException([`친구가 없습니다.`]);
-    }
-    return result;
-  }
-
-  async searchFriend(user: User, toFindUser: User): Promise<Friend[]> {
-    /* 친구인 경우, 자기 자신과 찾으려는 친구 각각이 requestor 혹은 receiver 둘 중 하나에는 무조건 있기 때문에
-        requestor가 자기 자신인 경우를 찾아 반환한다.*/
-    const result = await this.find({
-      relations: {
-        requestor: true,
-        receiver: true,
-      },
-      where: {
-        requestor: { id: Equal(user.id) },
-        receiver: { id: Equal(toFindUser.id) },
-        status: FriendStatus.FRIEND,
-      },
+    const friends = result.map((friend) => {
+      if (friend.requestor.id === user.id) {
+        return friend.receiver;
+      }
     });
-    if (Object.keys(result).length === 0) {
-      throw new NotFoundException([`친구가 아닙니다.`]);
-    }
-    return result;
+    return friends;
   }
 }

--- a/back-end/src/game/game.repository.ts
+++ b/back-end/src/game/game.repository.ts
@@ -3,6 +3,7 @@ import { Repository } from 'typeorm';
 import { GameMode } from './constants/game.mode.enum';
 import { GameRecord } from './entities/game.entity';
 import { User } from 'src/users/entities/user.entity';
+import { InternalServerErrorException } from '@nestjs/common';
 
 @CustomRepository(GameRecord)
 export class GameRepository extends Repository<GameRecord> {
@@ -13,7 +14,11 @@ export class GameRepository extends Repository<GameRecord> {
       rightUser: rightUser.id,
       type: GameMode.LADDER_GAME, // : gameMode.LADDER_GAME
     });
-    await this.save(game);
+    try {
+      await this.save(game);
+    } catch (error) {
+      throw new InternalServerErrorException();
+    }
     return game.id;
   }
 }

--- a/back-end/src/users/users.controller.ts
+++ b/back-end/src/users/users.controller.ts
@@ -4,8 +4,6 @@ import {
   Get,
   Param,
   Patch,
-  Post,
-  Res,
   UploadedFile,
   UseGuards,
   UseInterceptors,
@@ -49,11 +47,6 @@ export class UsersController {
   getProfile(@Param('nickname') nickname: string): Promise<User> {
     return this.usersService.findByNickname(nickname);
   }
-
-  //@ApiOperation({ summary: '내 정보 수정' })
-  //@ApiResponse({ status: 200, description: '내 정보 수정 성공' })
-  //@Patch('/me')
-  //updateMe(@GetUser() user: User, @Body() userToUpdate: UserDto) {}
 
   @ApiOperation({ summary: '유저 검색' })
   @ApiResponse({ status: 200, description: '유저 검색 성공' })

--- a/back-end/src/users/users.repository.ts
+++ b/back-end/src/users/users.repository.ts
@@ -45,6 +45,9 @@ export class UserRepository extends Repository<User> {
 
   async findById(id: string): Promise<User> {
     const user: User = await this.findOneBy({ id });
+    if (user === null) {
+      throw new NotFoundException(`User not found`);
+    }
     return user;
   }
 
@@ -59,9 +62,6 @@ export class UserRepository extends Repository<User> {
         nickname: Like(`%${search}%`),
       },
     });
-    if (users.length === 0) {
-      throw new NotFoundException(`User not found`);
-    }
     return users;
   }
 


### PR DESCRIPTION
- friend 요청 자기자신에게 보냈을시 예외처리
- friend 요청, 수락, 거절, 차단 return void로 수정, 따로 받아볼 데이터가 없음
- friend 수락과 거절은 응답에 대해 회신할때 닉네임이 변경될 수 있으므로 userId로 교체
- friend 검색은 프론트에서 처리하기로함
- friend exception 각 상황에 맞게 변경
- user/search는 404 말고 빈 배열로 전달해 주는 식으로 변경
- 모든 save에서 500 에러 핸들링 넣어줌
- friend 전체 조회시 User[] return 으로 변경, 친구 없을 때 빈 객체로 수정함