### PR TITLE
[TL-42 162] feat: 프로필 이미지 수정기능 외 사소한 수정

### DIFF
--- a/front-end/src/UI/Molecules/ModifiableUserName/index.tsx
+++ b/front-end/src/UI/Molecules/ModifiableUserName/index.tsx
@@ -38,6 +38,7 @@ function ModifiableUserName(props: { userName: string; isMyself: boolean }) {
         .then(() => {
           setModUserName(nickname);
           setIsEditing(false);
+          helper.setSubmitting(false);
         })
         .catch((err) => {
           if (err.response.status === 409) {
@@ -46,8 +47,8 @@ function ModifiableUserName(props: { userName: string; isMyself: boolean }) {
               bodyMessage: '중복된 닉네임입니다.',
             });
           }
+          helper.setSubmitting(false);
         });
-      helper.setSubmitting(false);
     },
     [setModUserName, setIsEditing],
   );

--- a/front-end/src/UI/Organisms/UserProfileInfo/index.tsx
+++ b/front-end/src/UI/Organisms/UserProfileInfo/index.tsx
@@ -8,7 +8,7 @@ import {
   Input,
 } from '@chakra-ui/react';
 import { MdAddPhotoAlternate } from 'react-icons/md';
-import { Field, Form, Formik } from 'formik';
+import axios from 'axios';
 import ModifiableUserName from '../../Molecules/ModifiableUserName';
 
 function UserProfileInfo(props: {
@@ -18,7 +18,14 @@ function UserProfileInfo(props: {
 }) {
   const { userName, userImage, isMyself } = props;
 
-  const onSubmitHandler = () => {};
+  const onChangeHandler = (event: { target: HTMLInputElement }): void => {
+    const { target } = event;
+    const formData = new FormData();
+    if (target.files?.length) {
+      formData.append('file', target.files[0]);
+      axios.patch('/users/me', formData);
+    }
+  };
 
   return (
     <HStack>
@@ -36,21 +43,16 @@ function UserProfileInfo(props: {
                 >
                   <MdAddPhotoAlternate />
                 </Box>
-                <Formik initialValues={{}} onSubmit={onSubmitHandler}>
-                  <Form>
-                    <Field
-                      name="image"
-                      as={Input}
-                      type="file"
-                      accept="image/*"
-                      position="absolute"
-                      top="0"
-                      left="0"
-                      opacity="0"
-                      cursor="pointer"
-                    />
-                  </Form>
-                </Formik>
+                <Input
+                  type="file"
+                  accept="image/jpeg"
+                  position="absolute"
+                  top="0"
+                  left="0"
+                  opacity="0"
+                  cursor="pointer"
+                  onChange={(event) => onChangeHandler(event)}
+                />
               </Box>
             </AspectRatio>
           </AvatarBadge>

--- a/front-end/src/UI/Pages/OTPRevise/index.tsx
+++ b/front-end/src/UI/Pages/OTPRevise/index.tsx
@@ -56,6 +56,9 @@ function OTPBody({
             2차인증이 활성화 되었습니다. 해제하려면 OTP 인증을 한 번 더
             수행하십시오.
           </Text>
+          <Box w="15vw" h="20vh" bgColor="blue.200">
+            대충 QR 코드 나타날 곳
+          </Box>
           <TwoFAInput
             size="30%"
             textColor="black"


### PR DESCRIPTION
스문님이 워닝알러트다이얼로그 훅을 완성하시면 그것을 이용해서
에러시에 행동을 추가하는 것이 남았다. 현재 patch를 이용해서 백엔드에
보냈을 때 로컬에 저장되는 것과 status 200을 반환하는 것으로 보아
프로필 이미지 수정이 잘 될 것 같다. 그리고 otprevise에서 2차인증
해제할때도 큐알코드를 보여줘야할 것 같아서 박스를 넣었다.
modifiableusername 에서는 async await을 안쓰기위해 스문님의 조언을얻어
setsubmitting 함수를 성공시 실패시 각각 사용하도록 코드를 수정하였다.