### PR TITLE
[TL42-190] fix : 프로필 사진 변경시 바로 렌더링

### DIFF
--- a/back-end/src/users/constants/multer.options.ts
+++ b/back-end/src/users/constants/multer.options.ts
@@ -15,7 +15,7 @@ export const loaclOptions: MulterOptions = {
     filename(req, file, cb) {
       const userId = req['user'].id;
       const fileMimeType = file.mimetype.split('/')[1];
-      cb(null, `${userId}.${fileMimeType}`);
+      cb(null, `${userId}.${new Date().getTime()}.${fileMimeType}`);
     },
   }),
   fileFilter: (req, file, cb) => {

--- a/back-end/src/users/entities/user.entity.ts
+++ b/back-end/src/users/entities/user.entity.ts
@@ -10,6 +10,8 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
+export const DEFAULT_PROFILE_IMG = 'files/profileImg/default.jpg';
+
 @Entity()
 export class User extends BaseEntity {
   @Column({ primary: true })
@@ -25,7 +27,7 @@ export class User extends BaseEntity {
   @Column()
   email: string;
 
-  @Column({ default: 'files/profileImg/default.jpg' })
+  @Column({ default: DEFAULT_PROFILE_IMG })
   profileImg: string;
 
   //@Column()

--- a/back-end/src/users/users.repository.ts
+++ b/back-end/src/users/users.repository.ts
@@ -6,7 +6,7 @@ import {
 import { Auth42userDto } from 'src/auth/dto/auth.42user.dto';
 import { Like, Repository } from 'typeorm';
 import { CustomRepository } from '../custom/typeorm.decorator';
-import { User } from './entities/user.entity';
+import { User, DEFAULT_PROFILE_IMG } from './entities/user.entity';
 
 @CustomRepository(User)
 export class UserRepository extends Repository<User> {
@@ -74,6 +74,14 @@ export class UserRepository extends Repository<User> {
       user.nickname = nickName;
     }
     if (profileImg) {
+      const fs = require('fs');
+      if (user.profileImg !== DEFAULT_PROFILE_IMG) {
+        fs.unlink(`${user.profileImg}`, (err) => {
+          if (err) {
+            throw new NotFoundException();
+          }
+        });
+      }
       user.profileImg = profileImg;
     }
     try {

--- a/back-end/src/users/users.repository.ts
+++ b/back-end/src/users/users.repository.ts
@@ -7,6 +7,7 @@ import { Auth42userDto } from 'src/auth/dto/auth.42user.dto';
 import { Like, Repository } from 'typeorm';
 import { CustomRepository } from '../custom/typeorm.decorator';
 import { User, DEFAULT_PROFILE_IMG } from './entities/user.entity';
+import * as fs from 'fs';
 
 @CustomRepository(User)
 export class UserRepository extends Repository<User> {
@@ -74,7 +75,6 @@ export class UserRepository extends Repository<User> {
       user.nickname = nickName;
     }
     if (profileImg) {
-      const fs = require('fs');
       if (user.profileImg !== DEFAULT_PROFILE_IMG) {
         fs.unlink(`${user.profileImg}`, (err) => {
           if (err) {

--- a/front-end/src/UI/Molecules/ModifiableUserName/index.tsx
+++ b/front-end/src/UI/Molecules/ModifiableUserName/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import React, { useState } from 'react';
 import {
   Text,
@@ -11,7 +12,9 @@ import * as Yup from 'yup';
 import { IoMdSave } from 'react-icons/io';
 import { ErrorMessage, Field, Form, Formik, FormikHelpers } from 'formik';
 import axios from 'axios';
+import { QueryClient, useQueryClient } from '@tanstack/react-query';
 import useWarningDialog from '../../../Hooks/useWarningDialog';
+import { useNavigate } from 'react-router-dom';
 
 type ChangeNameProps = {
   nickname: string;
@@ -26,6 +29,8 @@ function ModifiableUserName(props: { userName: string; isMyself: boolean }) {
   const [isEditing, setIsEditing] = useState(false);
   const [modUserName, setModUserName] = useState(userName);
   const { setError, WarningDialogComponent } = useWarningDialog();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const onSubmitHandler = React.useCallback(
     ({ nickname }: ChangeNameProps, helper: FormikHelpers<ChangeNameProps>) => {
@@ -33,8 +38,10 @@ function ModifiableUserName(props: { userName: string; isMyself: boolean }) {
         .patch('/users/me', { nickname })
         .then(() => {
           setModUserName(nickname);
+          queryClient.invalidateQueries(['me']);
           setIsEditing(false);
           helper.setSubmitting(false);
+          navigate(`/user/${nickname}`, { replace: true });
         })
         .catch((err) => {
           if (err.response.status === 409) {
@@ -46,7 +53,7 @@ function ModifiableUserName(props: { userName: string; isMyself: boolean }) {
           helper.setSubmitting(false);
         });
     },
-    [setModUserName, setIsEditing, setError],
+    [setModUserName, setIsEditing, setError, QueryClient, navigate],
   );
 
   if (!isMyself) {

--- a/front-end/src/UI/Molecules/ModifiableUserName/index.tsx
+++ b/front-end/src/UI/Molecules/ModifiableUserName/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, { useState } from 'react';
 import {
   Text,
@@ -8,13 +7,13 @@ import {
   InputGroup,
   InputRightElement,
 } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
 import * as Yup from 'yup';
 import { IoMdSave } from 'react-icons/io';
 import { ErrorMessage, Field, Form, Formik, FormikHelpers } from 'formik';
 import axios from 'axios';
-import { QueryClient, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import useWarningDialog from '../../../Hooks/useWarningDialog';
-import { useNavigate } from 'react-router-dom';
 
 type ChangeNameProps = {
   nickname: string;
@@ -53,7 +52,7 @@ function ModifiableUserName(props: { userName: string; isMyself: boolean }) {
           helper.setSubmitting(false);
         });
     },
-    [setModUserName, setIsEditing, setError, QueryClient, navigate],
+    [setModUserName, setIsEditing, setError, queryClient, navigate],
   );
 
   if (!isMyself) {

--- a/front-end/src/UI/Organisms/UserProfileInfo/index.tsx
+++ b/front-end/src/UI/Organisms/UserProfileInfo/index.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { useState } from 'react';
+import React from 'react';
 import {
   HStack,
   Avatar,
@@ -32,10 +31,6 @@ function UserProfileInfo(props: {
       });
     }
   };
-
-  React.useEffect(() => {
-    console.log(`Image rerender: ${userImage}`);
-  }, [userImage]);
 
   return (
     <HStack spacing={5} fontSize="5xl">

--- a/front-end/src/UI/Organisms/UserProfileInfo/index.tsx
+++ b/front-end/src/UI/Organisms/UserProfileInfo/index.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+/* eslint-disable */
+import React, { useState } from 'react';
 import {
   HStack,
   Avatar,
@@ -9,6 +10,7 @@ import {
 } from '@chakra-ui/react';
 import { MdAddPhotoAlternate } from 'react-icons/md';
 import axios from 'axios';
+import { useQueryClient } from '@tanstack/react-query';
 import ModifiableUserName from '../../Molecules/ModifiableUserName';
 
 function UserProfileInfo(props: {
@@ -17,15 +19,23 @@ function UserProfileInfo(props: {
   isMyself: boolean;
 }) {
   const { userName, userImage, isMyself } = props;
+  const queryClient = useQueryClient();
 
   const onChangeHandler = (event: { target: HTMLInputElement }): void => {
     const { target } = event;
     const formData = new FormData();
     if (target.files?.length) {
       formData.append('file', target.files[0]);
-      axios.patch('/users/me', formData);
+      axios.patch('/users/me', formData).then(() => {
+        queryClient.invalidateQueries(['profile', userName]);
+        queryClient.invalidateQueries(['me']);
+      });
     }
   };
+
+  React.useEffect(() => {
+    console.log(`Image rerender: ${userImage}`);
+  }, [userImage]);
 
   return (
     <HStack spacing={5} fontSize="5xl">


### PR DESCRIPTION
queryClient.invalidateQueries 메서드를 이용해서
바로 변경되게 하였다. 하지만 사진부분에서 파일 이름이
계속 똑같은 이슈가 있어서 똑똑한 리액트가 변경된게 없다고 생각해버렸다.
그래서 백엔드 코드도 같이 수정했다. 파일 이름 뒤에 날짜를 붙이고
새 파일이 있으면 이전파일은 지우도록 백엔드 코드에 추가를 해놓았다.