### PR TITLE
[TL42-193] feat: 유저 전적 정보

### DIFF
--- a/front-end/src/Props/RecordProps.ts
+++ b/front-end/src/Props/RecordProps.ts
@@ -1,0 +1,9 @@
+export default interface RecordProps {
+  id: string;
+  leftUserScore: number;
+  rightUserScore: number;
+  rightUserName: string;
+  rightUserImage: string;
+  isLadder: boolean;
+  type: string;
+}

--- a/front-end/src/Props/UserProfileProps.ts
+++ b/front-end/src/Props/UserProfileProps.ts
@@ -1,3 +1,6 @@
+import RecordProps from './RecordProps';
 import UserInfoProps from './UserInfoProps';
 
-export default interface UserProfileProps extends UserInfoProps {}
+export default interface UserProfileProps extends UserInfoProps {
+  records: RecordProps[];
+}

--- a/front-end/src/UI/Organisms/UserMatchHistory/index.tsx
+++ b/front-end/src/UI/Organisms/UserMatchHistory/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box } from '@chakra-ui/react';
 import UserMatch from '../../Molecules/UserMatch';
 import ElementList from '../ElementList';
+import RecordProps from '../../../Props/RecordProps';
 
 const matchHistories = [
   {
@@ -34,11 +35,38 @@ const matchHistories = [
     isRankedGame: true,
     isNormalMode: true,
   },
+  {
+    matchId: 4,
+    opponentUserName: 'test',
+    opponentUserImage:
+      'https://w.namu.la/s/cb44538b575f372318ce9c28cd806dde1e6ac146514283b57b696ad7226ca18971fdae5716367e639a3345594b8cdfbf119bcc971b7a686b17c0873402ad659d555a847603c4aa8462a6f783e206b9381a506042def4729ceb696cf6394d4db8',
+    userScore: 5,
+    opponentScore: 3,
+    isRankedGame: true,
+    isNormalMode: true,
+  },
+  {
+    matchId: 5,
+    opponentUserName: 'test2',
+    opponentUserImage:
+      'https://w.namu.la/s/cb44538b575f372318ce9c28cd806dde1e6ac146514283b57b696ad7226ca18971fdae5716367e639a3345594b8cdfbf119bcc971b7a686b17c0873402ad659d555a847603c4aa8462a6f783e206b9381a506042def4729ceb696cf6394d4db8',
+    userScore: 5,
+    opponentScore: 3,
+    isRankedGame: true,
+    isNormalMode: true,
+  },
 ];
 
-function UserMatchHistory() {
+function UserMatchHistory(props: { records: RecordProps[] }) {
+  const { records } = props;
   return (
-    <Box width="100%" height="100%" borderWidth="1px" borderRadius="md">
+    <Box
+      width="100%"
+      height="100%"
+      borderWidth="1px"
+      borderRadius="md"
+      overflowY="scroll"
+    >
       <ElementList>
         {matchHistories.map((m) => (
           <UserMatch
@@ -49,6 +77,20 @@ function UserMatchHistory() {
             opponentScore={m.opponentScore}
             isRankedGame={m.isRankedGame}
             isNormalMode={m.isNormalMode}
+          />
+        ))}
+        ;
+      </ElementList>
+      <ElementList>
+        {records.map((record) => (
+          <UserMatch
+            key={record.id}
+            opponentUserName={record.rightUserName}
+            opponentUserImage={record.rightUserImage}
+            userScore={record.leftUserScore}
+            opponentScore={record.rightUserScore}
+            isRankedGame={record.isLadder}
+            isNormalMode={record.type === 'CLASSIC'}
           />
         ))}
         ;

--- a/front-end/src/UI/Pages/Profile/index.tsx
+++ b/front-end/src/UI/Pages/Profile/index.tsx
@@ -13,7 +13,11 @@ function Profile() {
   const { data, isLoading, error } = useQuery(
     USERS_PROFILE_GET(name ?? myNickname),
   );
-  const { nickname, profileImg } = data ?? { nickname: '', profileImg: '' };
+  const { nickname, profileImg, records } = data ?? {
+    nickname: '',
+    profileImg: '',
+    records: [],
+  };
   let modalBody;
 
   if (isLoading) {
@@ -29,6 +33,7 @@ function Profile() {
         userRating={rankScore}
         userWins={7500}
         userLosses={2500}
+        records={records}
       />
     );
   }

--- a/front-end/src/UI/Templates/ProfileContent/index.tsx
+++ b/front-end/src/UI/Templates/ProfileContent/index.tsx
@@ -3,6 +3,7 @@ import { Box, VStack } from '@chakra-ui/react';
 import UserProfileInfo from '../../Organisms/UserProfileInfo';
 import UserGameInfo from '../../Organisms/UserGameInfo';
 import UserMatchHistory from '../../Organisms/UserMatchHistory';
+import RecordProps from '../../../Props/RecordProps';
 
 function ProfileContent(props: {
   nickname: string;
@@ -11,9 +12,17 @@ function ProfileContent(props: {
   userWins: number;
   userLosses: number;
   isMyself: boolean;
+  records: RecordProps[];
 }) {
-  const { nickname, userImage, userRating, userWins, userLosses, isMyself } =
-    props;
+  const {
+    nickname,
+    userImage,
+    userRating,
+    userWins,
+    userLosses,
+    isMyself,
+    records,
+  } = props;
 
   return (
     <Box w="100%" h="500px" paddingY={2}>
@@ -28,7 +37,7 @@ function ProfileContent(props: {
           userWins={userWins}
           userLosses={userLosses}
         />
-        <UserMatchHistory />
+        <UserMatchHistory records={records} />
       </VStack>
     </Box>
   );


### PR DESCRIPTION
백엔드에서 줄거라 기대하는 정보를 바탕으로
RecordProps 작성. 나중에 바뀔 수 있음.
유저 매치기록이 3개이상일 경우 스크롤 되도록 스타일 수정
전적기록 받아와서 하위 컴포넌트들 프롭스로 전달

https://user-images.githubusercontent.com/71748476/184469145-3f5d3074-1933-4856-8c3b-3a94817d0ef8.mov
