### PR TITLE
[TL42-195] fix: 채팅방 스크롤 문제 수정

### DIFF
--- a/front-end/src/UI/Organisms/ChatBody/index.tsx
+++ b/front-end/src/UI/Organisms/ChatBody/index.tsx
@@ -9,10 +9,15 @@ import { useChat } from '../../../Hooks/useChat';
 export default function ChatBody() {
   const [chat] = useChat();
   const chatViewRef = React.useRef<HTMLElement>(null);
-  const scrollBottom = React.useRef<HTMLDivElement>(null);
-  React.useLayoutEffect(() => {
-    if (scrollBottom.current) scrollBottom.current.scrollIntoView(true);
-  }, [chat]);
+  const scrollToBottom = (): void => {
+    if (chatViewRef.current) {
+      chatViewRef.current.scrollTop = chatViewRef.current.scrollHeight;
+    }
+  };
+
+  React.useEffect(() => {
+    scrollToBottom();
+  }, [chat.chats]);
 
   return (
     <Sidebar header={<ChatHeader />} sidebar={<ChatMembers />}>
@@ -20,7 +25,6 @@ export default function ChatBody() {
         {chat.chats.map((c) => (
           <ChatElement key={c.id} name={c.name} message={c.message} id={c.id} />
         ))}
-        <div ref={scrollBottom} />
       </ScrollableVStack>
     </Sidebar>
   );


### PR DESCRIPTION
스크롤바텀의 ref를 맨마지막 박스인 div에 걸어놓아서
스크롤을 하더라도 항상 맨 밑으로 가는 문제가 있었다.
채팅방에 입장하거나 채팅을 쳤을때만  스크롤이 맨 밑으로 가도록 수정

https://user-images.githubusercontent.com/71748476/184472852-3508589e-8657-463b-9ec2-7753e321ac3c.mov
