### PR TITLE
[TL42-199] fix: 인증 후 리다이렉션을 .env에서

### DIFF
--- a/back-end/.env.dev
+++ b/back-end/.env.dev
@@ -8,3 +8,4 @@ DB_DATABASE=transcendence
 42API_SECRET=4c8b5ed9d29636006d7106d57ac6a97f40b7711fa03cbe3eba1d1bbe49ecbd82
 42API_CALLBACK_URL=http://localhost:3000/auth/42/redirect
 JWT_SECRET_KEY=secret
+AUTH_REDIRECT_URL=http://localhost:3001

--- a/back-end/.env.prod
+++ b/back-end/.env.prod
@@ -8,3 +8,4 @@ DB_DATABASE=transcendence
 42API_SECRET=
 42API_CALLBACK_URL=http://localhost:4242/api/auth/42/redirect
 JWT_SECRET_KEY=secret_key
+AUTH_REDIRECT_URL=http://localhost:4242

--- a/back-end/src/auth/auth.controller.ts
+++ b/back-end/src/auth/auth.controller.ts
@@ -11,12 +11,14 @@ import {
 import { AuthGuard } from '@nestjs/passport';
 import { UsersService } from 'src/users/users.service';
 import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
 
 @Controller('auth')
 export class AuthController {
   constructor(
     private readonly userService: UsersService,
     private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
   ) {}
 
   @Get('/42')
@@ -41,6 +43,6 @@ export class AuthController {
       'Set-Cookie',
       `Authentication=${accessToken}; Path=/; Max-Age=36000`,
     );
-    res.redirect('http://localhost:3001/');
+    res.redirect(this.configService.get('AUTH_REDIRECT_URL'));
   }
 }


### PR DESCRIPTION
- http://localhost:3001/ 로 하드코딩된 리다이렉션 주소의 .env화