### PR TITLE
[TL42-XX] fix: 백엔드에서 넘어오는 변수명 대로 수정

### DIFF
--- a/front-end/src/Props/RecordProps.ts
+++ b/front-end/src/Props/RecordProps.ts
@@ -8,5 +8,5 @@ export default interface RecordProps {
   winUserScore: number;
   isLadder: boolean;
   type: string;
-  updatedAt: string;
+  updateAt: string;
 }

--- a/front-end/src/UI/Organisms/UserMatchHistory/index.tsx
+++ b/front-end/src/UI/Organisms/UserMatchHistory/index.tsx
@@ -5,7 +5,7 @@ import RecordProps from '../../../Props/RecordProps';
 
 function UserMatchHistory(props: { records: RecordProps[]; userName: string }) {
   const { records, userName } = props;
-  records.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  records.sort((a, b) => b.updateAt.localeCompare(a.updateAt));
 
   return (
     <Box


### PR DESCRIPTION
RecordProps 및 사용하는 곳에서 코드 간단 수정