### PR TITLE
[TL42-230] 실시간 친구 상태의 백엔드 구현

### DIFF
--- a/back-end/src/friend/friend.module.ts
+++ b/back-end/src/friend/friend.module.ts
@@ -9,6 +9,7 @@ import { AlertService } from 'src/alert/alert.service';
 import { AlertRepository } from 'src/alert/alert.Repository';
 import { GameService } from 'src/game/game.service';
 import { GameRepository } from 'src/game/game.repository';
+import { SocketModule } from 'src/socket/socket.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { GameRepository } from 'src/game/game.repository';
     TypeOrmExModule.forCustomRepository([GameRepository]),
     TypeOrmExModule.forCustomRepository([UserRepository]),
     TypeOrmExModule.forCustomRepository([AlertRepository]),
+    SocketModule,
   ],
   controllers: [FriendController],
   providers: [UsersService, FriendService, GameService, AlertService],

--- a/back-end/src/friend/friend.service.ts
+++ b/back-end/src/friend/friend.service.ts
@@ -51,7 +51,7 @@ export class FriendService {
       user.id,
       friends.map((f) => f.id),
     );
-    this.socketStateService.notifyTo(user.id, userId);
+    this.socketStateService.notifyOneByUserId(user.id, userId);
   }
 
   async rejectFriend(

--- a/back-end/src/friend/friend.service.ts
+++ b/back-end/src/friend/friend.service.ts
@@ -11,6 +11,7 @@ import { User } from 'src/users/entities/user.entity';
 import { Friend } from './entities/friend.entity';
 import { FriendStatus } from './constants/friend.enum';
 import { FriendListDto } from './dto/friend.list.dto';
+import { SocketStateService } from 'src/socket/socket-state.service';
 
 @Injectable()
 export class FriendService {
@@ -19,6 +20,7 @@ export class FriendService {
     private friendRepository: FriendRepository,
     private userService: UsersService,
     private alertService: AlertService,
+    private readonly socketStateService: SocketStateService,
   ) {}
 
   async findAllFriends(user: User): Promise<FriendListDto[]> {
@@ -44,6 +46,12 @@ export class FriendService {
     const opponentUser = await this.userService.findById(userId);
     await this.alertService.updateAlert(alertId);
     await this.friendRepository.acceptFriend(opponentUser, user);
+    const friends = await this.findAllFriends(user);
+    await this.socketStateService.retrieveState(
+      user.id,
+      friends.map((f) => f.id),
+    );
+    this.socketStateService.notifyTo(user.id, userId);
   }
 
   async rejectFriend(

--- a/back-end/src/socket/chat/constants/state.user.enum.ts
+++ b/back-end/src/socket/chat/constants/state.user.enum.ts
@@ -1,0 +1,8 @@
+enum UserState {
+  ONLINE = 'ONLINE',
+  OFFLINE = 'OFFLINE',
+  INGAME = 'INGAME',
+  OBSERVE = 'OBSERVE',
+}
+
+export default UserState;

--- a/back-end/src/socket/chat/dto/state.update.user.notify.dto.ts
+++ b/back-end/src/socket/chat/dto/state.update.user.notify.dto.ts
@@ -1,0 +1,6 @@
+import UserState from '../constants/state.user.enum';
+
+export default interface StateUpdateUserNotifyDto {
+  id: string;
+  state: UserState;
+}

--- a/back-end/src/socket/class/user.connected.class.ts
+++ b/back-end/src/socket/class/user.connected.class.ts
@@ -1,0 +1,8 @@
+import { Socket } from 'socket.io';
+import UserState from '../chat/constants/state.user.enum';
+
+export class UserConnected {
+  public state: UserState;
+
+  constructor(public readonly userId: string, public readonly socket: Socket) {}
+}

--- a/back-end/src/socket/game/constants/game.constants.ts
+++ b/back-end/src/socket/game/constants/game.constants.ts
@@ -73,6 +73,14 @@ enum SocketEventName {
   GAME_ACCEPT_RES = 'game-accept-res',
   GAME_REFUSE_RES = 'game-refuse-res',
   GAME_INVITE_NOTIFY = 'game-invite-notify',
+
+  CHAT_JOIN_NOTIFY = 'chat-join-notify',
+  CHAT_LEAVE_NOTIFY = 'chat-leave-notify',
+  CHAT_MESSAGE_NOTIFY = 'chat-message-notify',
+  CHAT_UPDATE_PROTECTION_NOTIFY = 'chat-update-protection-notify',
+  CHAT_UPDATE_USER_NOTIFY = 'chat-update-user-notify',
+
+  STATE_UPDATE_USER_NOTIFY = 'state-update-user-notify',
 }
 
 export {

--- a/back-end/src/socket/socket-state.service.ts
+++ b/back-end/src/socket/socket-state.service.ts
@@ -1,0 +1,109 @@
+import { Injectable, Logger } from '@nestjs/common';
+import UserState from './chat/constants/state.user.enum';
+import StateUpdateUserNotifyDto from './chat/dto/state.update.user.notify.dto';
+import { UserContext } from './class/user.class';
+import { UserConnected } from './class/user.connected.class';
+import { SocketEventName } from './game/constants/game.constants';
+
+@Injectable()
+export class SocketStateService {
+  private readonly logger = new Logger(SocketStateService.name);
+
+  // key: socket.id
+  private readonly connectedUsers = new Map<string, UserConnected>();
+
+  async onChangeState(
+    user: UserContext,
+    state: UserState,
+    notificationTargetUserIds?: string[],
+  ) {
+    let connectedUser = this.connectedUsers.get(user.id);
+    this.logger.debug(
+      `[${user.user.id}] change state to ${state} from ${
+        connectedUser?.state ?? 'UNKNOWN'
+      }`,
+    );
+    if (state === UserState.ONLINE) {
+      connectedUser = new UserConnected(user.user.id, user.socket);
+      connectedUser.state = state;
+      this.connectedUsers.set(user.id, connectedUser);
+    }
+    if (connectedUser) {
+      connectedUser.state = state;
+
+      this.executeTargets(notificationTargetUserIds, (entry) => {
+        this.logger.debug(
+          `[${user.user.id}] send to friend ${entry.userId} state '${entry.state}'`,
+        );
+        entry.socket.emit(SocketEventName.STATE_UPDATE_USER_NOTIFY, <
+          StateUpdateUserNotifyDto
+        >{
+          id: user.user.id,
+          state: connectedUser.state,
+        });
+      });
+    }
+    if (state === UserState.OFFLINE) {
+      this.connectedUsers.delete(user.id);
+    }
+  }
+
+  private findByUserId(userId: string) {
+    let ret: UserConnected | null = null;
+    const iterator = this.connectedUsers.values();
+    for (;;) {
+      const { value, done } = iterator.next();
+      if (done) break;
+      if (value.userId === userId) {
+        ret = value;
+        break;
+      }
+    }
+    return ret;
+  }
+
+  async retrieveState(selfUserId: string, desiredToKnowUserIds: string[]) {
+    const self = this.findByUserId(selfUserId);
+
+    // no self user found
+    if (!self) return;
+
+    this.executeTargets(desiredToKnowUserIds, (entry) => {
+      this.logger.debug(
+        `[${selfUserId}] retrieve state from friend ${entry.userId} state '${entry.state}'`,
+      );
+      self.socket.emit(SocketEventName.STATE_UPDATE_USER_NOTIFY, <
+        StateUpdateUserNotifyDto
+      >{
+        id: entry.userId,
+        state: entry.state,
+      });
+    });
+  }
+
+  executeTargets(
+    targetUserIds: string[],
+    callback: (target: UserConnected) => void,
+  ) {
+    this.connectedUsers.forEach((entry) => {
+      if (targetUserIds.includes(entry.userId)) {
+        callback(entry);
+      }
+    });
+  }
+
+  notifyTo(selfUserId: string, targetUserId: string) {
+    const self = this.findByUserId(selfUserId);
+    const target = this.findByUserId(targetUserId);
+
+    // no self user found
+    if (!self || !target) return;
+
+    target.socket.emit(SocketEventName.STATE_UPDATE_USER_NOTIFY, <
+      StateUpdateUserNotifyDto
+    >{
+      id: selfUserId,
+      state: self.state,
+    });
+  }
+}

--- a/back-end/src/socket/socket.gateway.ts
+++ b/back-end/src/socket/socket.gateway.ts
@@ -368,6 +368,7 @@ export class SocketGateway implements OnGatewayConnection, OnGatewayDisconnect {
           client.emit(SocketEventName.GAME_SPECTATE_RES, <GameSpectateResDto>{
             success: true,
           });
+          this.changeUserState(user, UserState.OBSERVE);
         }
         throw new Error('No user');
       }

--- a/back-end/src/socket/socket.module.ts
+++ b/back-end/src/socket/socket.module.ts
@@ -1,15 +1,18 @@
 import { Module } from '@nestjs/common';
+import { AlertRepository } from 'src/alert/alert.Repository';
+import { AlertService } from 'src/alert/alert.service';
 import { ChatRoomRepository } from 'src/chat/chat.room.repository';
 import { ChatService } from 'src/chat/chat.service';
 import { ChatUserRepository } from 'src/chat/chat.user.repository';
 import { TypeOrmExModule } from 'src/custom/typeorm.module';
+import { FriendRepository } from 'src/friend/friend.repository';
+import { FriendService } from 'src/friend/friend.service';
 import { GameRepository } from 'src/game/game.repository';
 import { GameService } from 'src/game/game.service';
-import { User } from 'src/users/entities/user.entity';
-import { UsersModule } from 'src/users/users.module';
 import { UserRepository } from 'src/users/users.repository';
 import { UsersService } from 'src/users/users.service';
 import { SocketGameService } from './game/socket-game.service';
+import { SocketStateService } from './socket-state.service';
 import { SocketGateway } from './socket.gateway';
 import { SocketService } from './socket.service';
 
@@ -19,16 +22,21 @@ import { SocketService } from './socket.service';
     TypeOrmExModule.forCustomRepository([GameRepository]),
     TypeOrmExModule.forCustomRepository([ChatRoomRepository]),
     TypeOrmExModule.forCustomRepository([ChatUserRepository]),
+    TypeOrmExModule.forCustomRepository([FriendRepository]),
+    TypeOrmExModule.forCustomRepository([AlertRepository]),
   ],
   controllers: [],
   providers: [
     SocketGateway,
     SocketService,
     SocketGameService,
+    SocketStateService,
     UsersService,
     GameService,
     ChatService,
+    FriendService,
+    AlertService,
   ],
-  exports: [SocketGateway],
+  exports: [SocketGateway, SocketStateService],
 })
 export class SocketModule {}

--- a/front-end/src/UI/Molecules/FriendElement/index.tsx
+++ b/front-end/src/UI/Molecules/FriendElement/index.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { Text, HStack, Spacer, Avatar, AvatarBadge } from '@chakra-ui/react';
+import {
+  Text,
+  HStack,
+  Spacer,
+  Avatar,
+  AvatarBadge,
+  VStack,
+} from '@chakra-ui/react';
 import { Link } from 'react-router-dom';
 import UserState from '../../../WebSockets/dto/constants/user.state.enum';
 
@@ -14,8 +21,22 @@ function FriendElement(props: {
     ONLINE: 'green.500',
     OFFLINE: 'red.500',
     INGAME: 'yellow.500',
-    OBSERVE: 'pink.500',
+    OBSERVE: 'blue.500',
   };
+  const statusText = React.useMemo(() => {
+    switch (connectionStatus) {
+      case UserState.ONLINE:
+        return '온라인';
+      case UserState.OFFLINE:
+        return '오프라인';
+      case UserState.INGAME:
+        return '게임중';
+      case UserState.OBSERVE:
+        return '관전중';
+      default:
+        return '오프라인';
+    }
+  }, [connectionStatus]);
 
   return (
     <HStack
@@ -37,7 +58,18 @@ function FriendElement(props: {
         <AvatarBadge boxSize="1em" bgColor={StatusColors[connectionStatus]} />
       </Avatar>
       <Spacer />
-      <Text opacity={isBlocked ? '35%' : '100%'}>{userName}</Text>
+      <VStack justifyContent="space-evenly">
+        <Text opacity={isBlocked ? '35%' : '100%'}>{userName}</Text>
+        <Text
+          w="full"
+          fontSize="xs"
+          fontWeight="bold"
+          textAlign="right"
+          textColor={StatusColors[connectionStatus]}
+        >
+          {statusText}
+        </Text>
+      </VStack>
     </HStack>
   );
 }


### PR DESCRIPTION
- 순환참조를 해결하기 위해 `SocketStateService` 를 새로 구현.
- 온라인, 오프라인, 게임중, 관전중 상태 모두 처리.
- 실시간으로 유저의 온라인 상태를 친구들에게 보내줌.
- 친구 관계가 새로이 설정되었을때, 현재 친구의 온라인 상태를 즉시 확인 가능.