### PR TITLE
[TL42-206] feat: 첫 로그인 설정 페이지 구현

### DIFF
--- a/front-end/src/Hooks/useApp.ts
+++ b/front-end/src/Hooks/useApp.ts
@@ -27,12 +27,12 @@ export function useApp() {
     setCookie('Authentication', '', { path: '/' });
     setAuthCookie('');
   }, [setAuthCookie]);
-  const { id: firstLogin } = useMe();
+  const { isFirstLogin } = useMe();
   const status = React.useMemo(() => {
     const err = error as AxiosError<any, any> | null;
     if (!authCookie) return AppStatus.NeedLogin;
     if (isLoading) return AppStatus.NowLoading;
-    if (!firstLogin) return AppStatus.NeedInitialSetup;
+    if (isFirstLogin) return AppStatus.NeedInitialSetup;
     if (err?.response?.status === 401) {
       if (err?.response?.data.message === 'TFA not authenticated')
         return AppStatus.NeedOTPLogin;
@@ -41,6 +41,6 @@ export function useApp() {
     }
     if (error) return AppStatus.Error;
     return AppStatus.Authenticated;
-  }, [firstLogin, isLoading, error, logout, authCookie]);
+  }, [isFirstLogin, isLoading, error, logout, authCookie]);
   return { status, logout };
 }

--- a/front-end/src/Hooks/useMe.ts
+++ b/front-end/src/Hooks/useMe.ts
@@ -10,6 +10,7 @@ export default function useMe() {
       profileImg: 'https://cdn.intra.42.fr/users/3b3.jpg',
       rankScore: 0,
       tfaEnabled: false,
+      isFirstLogin: false,
     };
   }
   if (error) {
@@ -19,6 +20,7 @@ export default function useMe() {
       profileImg: 'https://cdn.intra.42.fr/users/3b3.jpg',
       rankScore: 0,
       tfaEnabled: false,
+      isFirstLogin: false,
     };
   }
   return data;

--- a/front-end/src/Hooks/useMessage.ts
+++ b/front-end/src/Hooks/useMessage.ts
@@ -35,19 +35,17 @@ export default function useMessage() {
   );
   const displayDMHistory = React.useCallback(
     (targetName: string) => {
-      axios
-        .get(`/dm/${targetName}`)
-        .then((response) => {
-          const DMList: ChatMessageProps[] = response.data;
-          DMList.forEach((dm) => {
-            dispatch({
-              action: 'chat',
-              name: dm.senderNickName,
-              message: dm.content,
-            });
+      axios.get(`/dm/${targetName}`).then((response) => {
+        const DMList: ChatMessageProps[] = response.data;
+        DMList.forEach((dm) => {
+          dispatch({
+            action: 'chat',
+            name: dm.senderNickName,
+            message: dm.content,
           });
-        })
-        .catch((err) => console.log(err));
+        });
+      });
+      // .catch((err) => console.log(err));
     },
     [dispatch],
   );

--- a/front-end/src/Props/UserInfoProps.ts
+++ b/front-end/src/Props/UserInfoProps.ts
@@ -4,4 +4,5 @@ export default interface UserInfoProps {
   profileImg: string;
   rankScore: number;
   tfaEnabled: boolean;
+  isFirstLogin: boolean;
 }

--- a/front-end/src/UI/Pages/InitialSetup/index.tsx
+++ b/front-end/src/UI/Pages/InitialSetup/index.tsx
@@ -5,10 +5,7 @@ import {
   VStack,
   Input,
   AvatarBadge,
-  InputGroup,
-  InputRightElement,
   Button,
-  Icon,
   Text,
   Center,
   Image,
@@ -17,13 +14,13 @@ import * as Yup from 'yup';
 import { ErrorMessage, Field, Form, Formik, FormikHelpers } from 'formik';
 import { HiPencilAlt } from 'react-icons/hi';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { IoMdSave } from 'react-icons/io';
 import axios from 'axios';
 import USERS_ME_GET from '../../../Queries/Users/Me';
 import useWarningDialog from '../../../Hooks/useWarningDialog';
 
-type ChangeNameProps = {
+type InitialSetupProps = {
   submitName: string;
+  image?: File;
 };
 
 const ChangeNameScheme = Yup.object().shape({
@@ -36,27 +33,44 @@ export default function InitialSetup() {
     nickname: 'undefined',
     profileImg: '',
   };
+  const [currentProfileImg, setCurrentProfileImg] = useState(
+    `${process.env.REACT_APP_API_HOST}/${profileImg}`,
+  );
   const [inputName, setInputName] = useState(nickname);
   const queryClient = useQueryClient();
   const { setError, WarningDialogComponent } = useWarningDialog();
 
   const onSubmitHandler = React.useCallback(
     (
-      { submitName }: ChangeNameProps,
-      helper: FormikHelpers<ChangeNameProps>,
+      { submitName, image }: InitialSetupProps,
+      helper: FormikHelpers<InitialSetupProps>,
     ) => {
+      const formData = new FormData();
+      if (image) formData.append('file', image);
+      formData.append('nickname', submitName);
       axios
-        .patch('/users/me', { nickname: submitName })
+        .patch('/users/me', formData)
         .then(() => {
           setInputName(submitName);
           queryClient.invalidateQueries(['me']);
           helper.setSubmitting(false);
         })
-        .catch(() => {
+        .catch((err) => {
+          if (err.response) {
+            setError({
+              headerMessage: '사용자 설정 실패',
+              bodyMessage: err.response.data.message,
+            });
+          } else {
+            setError({
+              headerMessage: '사용자 설정 실패',
+              bodyMessage: err.message,
+            });
+          }
           helper.setSubmitting(false);
         });
     },
-    [queryClient],
+    [queryClient, setError],
   );
 
   const imageFormRef = React.useRef<HTMLInputElement>(null);
@@ -64,110 +78,83 @@ export default function InitialSetup() {
     imageFormRef.current?.click();
   }, [imageFormRef]);
   const onChangeHandler = React.useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (
+      e: React.ChangeEvent<HTMLInputElement>,
+      setFieldValue: (
+        field: string,
+        value: any,
+        shouldValidate?: boolean | undefined,
+      ) => void,
+    ) => {
       if (!e.target.files) return;
-      const file = e.target.files[0];
-      const formData = new FormData();
-      formData.append('file', file);
-      axios
-        .patch('/users/me', formData)
-        .then(() => {
-          queryClient.invalidateQueries(['me']);
-        })
-        .catch((err) => {
-          if (err.response) {
-            setError({
-              headerMessage: '이미지 변경 실패',
-              bodyMessage: err.response.data.message,
-            });
-          } else {
-            setError({
-              headerMessage: '이미지 변경 실패',
-              bodyMessage: err.message,
-            });
-          }
-        });
+      setFieldValue('image', e.target.files[0]);
+      setCurrentProfileImg(URL.createObjectURL(e.target.files[0]));
     },
-    [queryClient, setError],
+    [],
   );
-  const onCommitHandler = React.useCallback(() => {
-    // TODO: 첫번째 로그인 비활성화 API 호출
-    axios.patch('/users/me', { commit: true }).then(() => {
-      queryClient.invalidateQueries(['me']);
-    });
-  }, [queryClient]);
-
   return (
-    <Center w="100%" h="100vh">
-      <VStack h="100%" justifyContent="center">
-        <Image src="logo.svg" alt="Atomic Pong" mb="4em" />
-        <Box boxSize="sm" p={10}>
-          <Avatar
-            src={`${process.env.REACT_APP_API_HOST}/${profileImg}`}
-            size="full"
-          >
-            <AvatarBadge borderWidth={0}>
-              <Box>
-                <Box
-                  as={Button}
-                  position="relative"
-                  height="100%"
-                  width="100%"
-                  transform="translate(-10%, -15%)"
-                  fontSize="6xl"
-                  onClick={onClickHandler}
-                  cursor="pointer"
-                  borderRadius="full"
-                  textColor="black"
-                  p={2}
-                >
-                  <HiPencilAlt />
-                </Box>
-                <Input
-                  type="file"
-                  accept="image/*"
-                  ref={imageFormRef}
-                  onChange={onChangeHandler}
-                  style={{ display: 'none' }}
+    <Formik
+      initialValues={{ submitName: inputName }}
+      onSubmit={onSubmitHandler}
+      validationSchema={ChangeNameScheme}
+    >
+      {({ isSubmitting, setFieldValue }) => (
+        <Center w="100%" h="100vh">
+          <VStack h="100%" justifyContent="center">
+            <Image src="logo.svg" alt="Atomic Pong" mb="4em" />
+            <Box boxSize="sm" p={10}>
+              <Avatar src={currentProfileImg} size="full">
+                <AvatarBadge borderWidth={0}>
+                  <Box>
+                    <Box
+                      as={Button}
+                      position="relative"
+                      height="100%"
+                      width="100%"
+                      transform="translate(-10%, -15%)"
+                      fontSize="6xl"
+                      onClick={onClickHandler}
+                      cursor="pointer"
+                      borderRadius="full"
+                      textColor="black"
+                      p={2}
+                    >
+                      <HiPencilAlt />
+                    </Box>
+                    <Input
+                      type="file"
+                      accept="image/*"
+                      ref={imageFormRef}
+                      onChange={(e) => onChangeHandler(e, setFieldValue)}
+                      style={{ display: 'none' }}
+                    />
+                  </Box>
+                </AvatarBadge>
+              </Avatar>
+            </Box>
+            <Form>
+              <Box width="xs">
+                <Field
+                  as={Input}
+                  name="submitName"
+                  variant="flushed"
+                  textColor="white"
+                  size="lg"
                 />
-              </Box>
-            </AvatarBadge>
-          </Avatar>
-        </Box>
-        <Box width="xs">
-          <Formik
-            initialValues={{ submitName: inputName }}
-            onSubmit={onSubmitHandler}
-            validationSchema={ChangeNameScheme}
-          >
-            {({ isSubmitting }) => (
-              <Form>
-                <InputGroup>
-                  <Field
-                    as={Input}
-                    name="submitName"
-                    variant="flushed"
-                    textColor="white"
-                    size="lg"
-                  />
-                  <InputRightElement>
-                    <Button type="submit" isLoading={isSubmitting}>
-                      <Icon as={IoMdSave} boxSize="1.5em" />
-                    </Button>
-                  </InputRightElement>
-                </InputGroup>
                 <Text fontSize="xs" textColor="red.500">
                   <ErrorMessage name="submitName" />
                 </Text>
-              </Form>
-            )}
-          </Formik>
-        </Box>
-        <Center pt="3em">
-          <Button onClick={onCommitHandler}>설정 완료</Button>
+              </Box>
+              <Center pt="3em">
+                <Button type="submit" isLoading={isSubmitting}>
+                  설정 완료
+                </Button>
+              </Center>
+            </Form>
+          </VStack>
+          {WarningDialogComponent}
         </Center>
-      </VStack>
-      {WarningDialogComponent}
-    </Center>
+      )}
+    </Formik>
   );
 }


### PR DESCRIPTION
 - 처음 닉네임 및 사진 설정 후, 설정 완료 버튼을 눌러서 저장한 후에 메인
   페이지로 넘어갈 수 있음.
 - 사진 및 닉네임에서 오류 (닉네임 중복 등)가 발생하면 넘어가지지 않음.

<img width="843" alt="image" src="https://user-images.githubusercontent.com/40755203/185826382-2a1ce7e6-6275-4c93-8df6-c4b401222277.png">
<img width="814" alt="image" src="https://user-images.githubusercontent.com/40755203/185826426-a6b3e826-d8d6-4eb3-a15d-5cc897a38eb4.png">
<img width="1345" alt="image" src="https://user-images.githubusercontent.com/40755203/185826449-f3a8938b-6ab9-425c-94e0-b5f1a63e36c8.png">
