### PR TITLE
[TL42-245] feat: 컨텍스트 메뉴 역할따라 렌더링

### DIFF
--- a/front-end/src/UI/Organisms/ChatMembers/index.tsx
+++ b/front-end/src/UI/Organisms/ChatMembers/index.tsx
@@ -5,10 +5,16 @@ import ScrollableVStack from '../../Atoms/ScrollableVStack';
 import ChatMemberElement from '../../Molecules/ChatMemberElement';
 import ChatModalContext from '../ChatModal/ChatModalContext';
 import UserContextMenu from '../../Templates/UserContextMenu';
+import useMe from '../../../Hooks/useMe';
 
 export default function ChatMembers() {
   const [chat] = useChat();
   const ref = React.useContext(ChatModalContext);
+  const { nickname: myName } = useMe();
+  const me =
+    chat.chatMembers[
+      chat.chatMembers.findIndex((member) => member.name === myName)
+    ];
   return (
     <VStack>
       <HStack w="full" justifyContent="space-between">
@@ -19,10 +25,13 @@ export default function ChatMembers() {
         {chat.chatMembers.map((member) => (
           <UserContextMenu
             env={ref?.current ?? document}
+            userId={member.userId}
+            name={member.name}
+            muted={member.muted}
+            role={member.role}
             key={member.name}
-            target={member.userId}
-            targetName={member.name}
             mode={chat.chatInfo.roomType === 'PRIVATE' ? 'friend' : 'chat'}
+            me={me}
           >
             <ChatMemberElement
               userId={member.userId}

--- a/front-end/src/UI/Organisms/MainSocialMyProfile/index.tsx
+++ b/front-end/src/UI/Organisms/MainSocialMyProfile/index.tsx
@@ -31,7 +31,7 @@ function ProfileContent({
 function MyProfile() {
   const { id, nickname, profileImg } = useMe();
   return (
-    <UserContextMenu target={id} targetName={nickname} mode="self">
+    <UserContextMenu userId={id} name={nickname} mode="self">
       <ProfileContent
         nickname={nickname}
         profileImg={`${process.env.REACT_APP_API_HOST}/${profileImg}`}

--- a/front-end/src/UI/Organisms/MainSocialTabPanelFriend/index.tsx
+++ b/front-end/src/UI/Organisms/MainSocialTabPanelFriend/index.tsx
@@ -39,8 +39,8 @@ function FriendTab() {
           .map((f) => (
             <UserContextMenu
               key={f.id}
-              target={f.id}
-              targetName={f.nickname}
+              userId={f.id}
+              name={f.nickname}
               mode="friend"
             >
               <FriendElement


### PR DESCRIPTION
- me를 ChatMembers에서 props로 넘겨주도록 변경
- member의 role을 추가해서 me의 role과 target의 role에 따라 다르게
  렌더링 되도록 변경