### PR TITLE
[TL42-XX] fix: 랭크스코어, 채팅방 생성 후 입장

### DIFF
--- a/front-end/src/Hooks/useChatRoomInfo.ts
+++ b/front-end/src/Hooks/useChatRoomInfo.ts
@@ -5,6 +5,7 @@ import { useParams } from 'react-router-dom';
 import ChannelType from '../Props/ChannelType';
 import ROOM_GET from '../Queries/Channels/Room';
 import useMessage from './useMessage';
+import { ChatStateRequestType, useChatState } from './useChatState';
 
 export default function useChatRoomInfo() {
   const { id } = useParams();
@@ -12,16 +13,18 @@ export default function useChatRoomInfo() {
   const queryClient = useQueryClient();
   const { dispatchRoomInfo } = useMessage();
   const { error, isLoading, data } = useQuery(ROOM_GET(chatRoomId));
+  const { setRequest } = useChatState();
 
   // cleanup
   React.useEffect(() => {
     if (!chatRoomId || error || isLoading) return () => {};
     return () => {
+      setRequest({ type: ChatStateRequestType.JOIN });
       axios
         .delete(`/chat/leave/${chatRoomId}`)
         .then(() => queryClient.invalidateQueries(['channels']));
     };
-  }, [chatRoomId, error, isLoading, queryClient]);
+  }, [chatRoomId, error, isLoading, queryClient, setRequest]);
 
   // room info
   React.useEffect(() => {

--- a/front-end/src/Props/UserProfileProps.ts
+++ b/front-end/src/Props/UserProfileProps.ts
@@ -5,4 +5,5 @@ export default interface UserProfileProps extends UserInfoProps {
   gameRecord: RecordProps[];
   winCount: number;
   loseCount: number;
+  rankScore: number;
 }

--- a/front-end/src/UI/Pages/Profile/index.tsx
+++ b/front-end/src/UI/Pages/Profile/index.tsx
@@ -9,7 +9,7 @@ import useMe from '../../../Hooks/useMe';
 
 function Profile() {
   const { id: chatid, userName, name } = useParams();
-  const { nickname: myNickname, rankScore } = useMe();
+  const { nickname: myNickname } = useMe();
   const { data, isLoading, error } = useQuery(
     USERS_PROFILE_GET(name ?? myNickname),
   );
@@ -23,13 +23,15 @@ function Profile() {
     return '/';
   }, [chatid, userName]);
 
-  const { nickname, profileImg, gameRecord, winCount, loseCount } = data ?? {
-    nickname: '',
-    profileImg: '',
-    gameRecord: [],
-    winCount: 0,
-    loseCount: 0,
-  };
+  const { nickname, profileImg, gameRecord, winCount, loseCount, rankScore } =
+    data ?? {
+      rankScore: 0,
+      nickname: '',
+      profileImg: '',
+      gameRecord: [],
+      winCount: 0,
+      loseCount: 0,
+    };
   let modalBody;
 
   if (isLoading) {


### PR DESCRIPTION
- 채팅방에서 상대 정보보기 눌렀을 때, 내 랭크스코어가 나오는 문제 해결
- 채팅방 생성후 나간다음 다른방 입장시 오류나던 것 해결. 클리어 부분에서
setRequest로 타입을 조인으로 바꿔줌.