### PR TITLE
[TL42-XX] fix: 채팅방 비번입력창 제출 후 초기화

### DIFF
--- a/front-end/src/UI/Molecules/ProtectedChannelElement/index.tsx
+++ b/front-end/src/UI/Molecules/ProtectedChannelElement/index.tsx
@@ -9,7 +9,7 @@ import {
   PopoverTrigger,
   Text,
 } from '@chakra-ui/react';
-import { ErrorMessage, Field, Form, Formik } from 'formik';
+import { ErrorMessage, Field, Form, Formik, FormikHelpers } from 'formik';
 import { useNavigate } from 'react-router-dom';
 import * as Yup from 'yup';
 import ChannelElement from '../ChannelElement';
@@ -31,8 +31,13 @@ function PasswordValidation(props: { chatRoomId: string }) {
   const navigate = useNavigate();
   const { setRequest } = useChatState();
   const onSubmitHandler = React.useCallback(
-    ({ password }: { password: string }) => {
+    (
+      { password }: { password: string },
+      helper: FormikHelpers<{ password: string }>,
+    ) => {
       setRequest({ type: ChatStateRequestType.JOIN, password: { password } });
+      helper.resetForm();
+      helper.setSubmitting(false);
       navigate(`/chat/${chatRoomId}`);
     },
     [chatRoomId, navigate, setRequest],


### PR DESCRIPTION
- 채팅방 비번입력을 한 후 초기화 및 setSubmitting을 false로 해주지
  않아서 방을 나간 후 다시 들어가려고 누르면 이전 상태에서 제출된 상태로
  계속 동그라미 돌던 문제 수정